### PR TITLE
Do not resort to windows path manipulation (re-re-re fix issue #2)

### DIFF
--- a/lib/htmlprocessor.js
+++ b/lib/htmlprocessor.js
@@ -130,7 +130,7 @@ HTMLProcessor.prototype.replaceWith = function replaceWith(block) {
 
   // Determine the relative path from the destination to the source
   // file
-  var dest = path.relative( this.relativePath, block.dest);
+  var dest = this.relativePath ? block.dest.replace(this.relativePath + '/', '') : block.dest;
 
   if (block.type === 'css') {
     result = block.indent + '<link rel="stylesheet" href="' + dest + '"\/>';


### PR DESCRIPTION
Using Windows path manipulation is not a good idea in our case, as the path in HTML files are usually expressed the Unix way.
