### PR TITLE
Updated revvedfinder to take revs with trailing hex characters into account.

### DIFF
--- a/lib/revvedfinder.js
+++ b/lib/revvedfinder.js
@@ -59,7 +59,7 @@ RevvedFinder.prototype.find = function find(ofile, basedir) {
     // is matching the path of the original file (to avoid clashes when there's a images/2123.test.png and
     // a images/misc/4567.test.png for example)
     var filepaths = this.expandfn('**/*' + basename);
-    var re = new RegExp('\\d+\\.' + basename + '$');
+    var re = new RegExp('[0-9a-fA-F]+\\.' + basename + '$');
     var filepath = filepaths.filter(function (f) {
         return f.match(re) && (normalizedDirname === path.dirname(f));
       })[0];

--- a/test/test-revvedfinder.js
+++ b/test/test-revvedfinder.js
@@ -36,6 +36,13 @@ describe('RevvedFinder', function () {
       assert.equal('bar/2345.image.png', rf.find('bar/image.png', '.'));
     });
 
+    it('should return revved version if it ends hex in characters', function () {
+      var rf = new RevvedFinder(function () {
+        return ['11916fba.image.png'];
+      });
+      assert.equal('11916fba.image.png', rf.find('image.png', '.'));
+    });
+
     it('should return the file if not revved version is found', function () {
       var rf = new RevvedFinder(function () {
         return [];


### PR DESCRIPTION
fixes #25.
- Changed filtering RegExp to match hex characters instead of just digits.
