### PR TITLE
Limit the subdirectories looked for revved files (Fixes #28)

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,12 @@ Default: 'cssmin'
 
 Name of the tool used to minify the CSS.
 
+### dirs
+Type: 'array of strings'
+Default: nil
+
+Used to limit the directories that will be looked for revved files when replacing reference. By default all subdirectories are looked at.
+
 ## The usemin task
 
 This task is responsible for replacing in HTML and CSS files, references to non-minified files with reference to their minified/revved version if they are found on the disk.
@@ -89,7 +95,10 @@ This task is responsible for replacing in HTML and CSS files, references to non-
 ```js
 usemin: {
   html: ['**/*.html'],
-  css: ['**/*.css']
+  css: ['**/*.css'],
+  options: {
+    dirs: ['temp', 'dist']
+  }
 }
 ```
 

--- a/lib/revvedfinder.js
+++ b/lib/revvedfinder.js
@@ -4,11 +4,20 @@ var path = require('path');
 // Allow to find, on disk, the revved version of a furnished file, bellow a given
 // directory
 //
-// +base_dir+  : the base repository which will be the root for our search
 // +expandfn+ : a function that will return a list of file matching a given pattern (for example grunt.file.expand)
+// +dirs+: restrict the search to these subdirectories
 //
-var RevvedFinder = module.exports = function (expandfn) {
+var RevvedFinder = module.exports = function (expandfn, dirs) {
     this.expandfn = expandfn;
+    this.dirs = dirs;
+
+    if (!dirs || dirs.length === 0) {
+        this.dirs_string = '';
+    } else if (dirs.length == 1) {
+        this.dirs_string = dirs[0] + '/';
+    } else {
+        this.dirs_string = '{' + dirs.join(',') + '}/';
+    }
   };
 
 //
@@ -58,10 +67,10 @@ RevvedFinder.prototype.find = function find(ofile, basedir) {
     // Once we found a couple of these files, we're filtering them out to be sure their path
     // is matching the path of the original file (to avoid clashes when there's a images/2123.test.png and
     // a images/misc/4567.test.png for example)
-    var filepaths = this.expandfn('**/*' + basename);
+    var filepaths = this.expandfn(this.dirs_string + '**/*' + basename);
     var re = new RegExp('[0-9a-fA-F]+\\.' + basename + '$');
     var filepath = filepaths.filter(function (f) {
-        return f.match(re) && (normalizedDirname === path.dirname(f));
+        return f.match(re) && (path.dirname(f).match(normalizedDirname));
       })[0];
 
     // not a file in temp, skip it

--- a/tasks/usemin.js
+++ b/tasks/usemin.js
@@ -77,6 +77,7 @@ module.exports = function (grunt) {
     };
     var name = this.target;
     var data = this.data;
+    var options = this.options();
     var files = grunt.file.expand(data);
 
     files.map(grunt.file.read).forEach(function (content, i) {
@@ -90,7 +91,7 @@ module.exports = function (grunt) {
       content = content.toString();
 
       // Our revved version locator
-      var revvedfinder = new RevvedFinder(grunt.file.expand);
+      var revvedfinder = new RevvedFinder(grunt.file.expand, options.dirs);
 
       // ext-specific directives handling and replacement of blocks
       var proc = new processors[name](filepath, content, revvedfinder, function (msg) {

--- a/test/test-revvedfinder.js
+++ b/test/test-revvedfinder.js
@@ -68,5 +68,13 @@ describe('RevvedFinder', function () {
       });
       assert.equal('fred.html', rf.find('fred.html', '.'));
     });
+
+    it('should restrict to the furnished subdirectories', function () {
+      var rf = new RevvedFinder(function (pattern) {
+        assert.equal(pattern, '{temp,dist}/**/*fred.html');
+        return['fred.html'];
+      }, ['temp', 'dist']);
+      rf.find('fred.html', '.');
+    });
   });
 });

--- a/test/test-usemin.js
+++ b/test/test-usemin.js
@@ -153,6 +153,38 @@ describe('usemin', function () {
     assert.ok(changed.match('<a href="foo.html"></a>'));
   });
 
+  it('should limit search to selected directories when asked to', function () {
+    grunt.log.muted = true;
+    grunt.config.init();
+    grunt.config('usemin', {html: 'index.html', options: { dirs: ['build']}});
+    grunt.file.mkdir('ape');
+    grunt.file.mkdir('ape/images');
+    grunt.file.mkdir('ape/images/misc');
+    grunt.file.write('ape/images/23013.test.png', 'foo');
+    grunt.file.write('ape/images/misc/2a437.test.png', 'foo');
+
+    grunt.file.mkdir('build');
+    grunt.file.mkdir('build/images');
+    grunt.file.mkdir('build/images/misc');
+    grunt.file.write('build/images/23012.test.png', 'foo');
+    grunt.file.write('build/images/misc/2a436.test.png', 'foo');
+    grunt.file.copy(path.join(__dirname, 'fixtures/relative_path.html'), 'index.html');
+    grunt.task.run('usemin');
+    grunt.task.start();
+
+
+    var changed = grunt.file.read('index.html');
+
+    // Check replace has performed its duty
+    assert.ok(changed.match(/<script src=\"scripts\/foo\.js\"><\/script>/));
+    assert.ok(changed.match(/<script src=\"scripts\/amd-app\.js\"><\/script>/));
+    assert.ok(changed.match(/img[^\>]+src=['"]images\/23012\.test\.png["']/));
+    assert.ok(changed.match(/img[^\>]+src=['"]images\/misc\/2a436\.test\.png["']/));
+    assert.ok(changed.match(/img[^\>]+src=['"]\/\/images\/test\.png["']/));
+    assert.ok(changed.match(/img[^\>]+src=['"]\/images\/23012\.test\.png["']/));
+  });
+
+
   describe('useminPrepare', function () {
     it('should update the config (HTML)', function () {
       grunt.log.muted = true;


### PR DESCRIPTION
Added a `dirs` option.
