### PR TITLE
Ensure data-main references a .js file

### DIFF
--- a/lib/htmlprocessor.js
+++ b/lib/htmlprocessor.js
@@ -186,6 +186,10 @@ HTMLProcessor.prototype.replaceWithRevved = function replaceWithRevved(lines) {
       [/<img[^\>]+src=['"]([^"']+)["']/gm,
       'Update the HTML with the new img filenames'
       ],
+      [/data-main\s*=['"]([^"']+)['"]/gm,
+      'Update the HTML with data-main tags',
+      function(m) { return m.match(/\.js$/) ? m : m + ".js"; }
+      ],
       [/data-[A-Za-z0-9]*=['"]([^"']+)["']/gm,
       'Update the HTML with the data tags'
       ],
@@ -199,16 +203,20 @@ HTMLProcessor.prototype.replaceWithRevved = function replaceWithRevved(lines) {
       'Update the HTML with reference in input'
       ]
     ];
+    var identity = function (m) { return m; };
 
     // Replace reference to script with the actual name of the revved script
     regexps.forEach(function (rxl) {
+      var filter = rxl[2] || identity;
+
       self.log(rxl[1]);
       content = content.replace(rxl[0], function (match, src) {
         // Consider reference from site root
-        var file = self.revvedfinder.find(src, path.dirname(self.filepath));
+        var srcfile = filter(src);
+        var file = self.revvedfinder.find(srcfile, path.dirname(self.filepath));
         var res = match.replace(src, file);
 
-        if (src !== file) {
+        if (srcfile !== file) {
           self.log(match + ' changed to ' + res);
         }
         return res;

--- a/test/fixtures/usemin.html
+++ b/test/fixtures/usemin.html
@@ -75,6 +75,8 @@
     <script data-main="scripts/main" src="scripts/vendor/require.js"></script>
     <!-- endbuild -->
 
+    <script data-main="scripts/main" src="scripts/vendor/require.js"></script>
+
     <img src="images/test.png">
     <img src="images/misc/test.png">
     <img src="//images/test.png">

--- a/test/test-usemin.js
+++ b/test/test-usemin.js
@@ -47,7 +47,6 @@ describe('usemin', function () {
     var changed = grunt.file.read('index.html');
 
     // Check replace has performed its duty
-    // console.log(changed);
     assert.ok(changed.match(/img[^\>]+src=['"]images\/23012\.test\.png["']/));
     assert.ok(changed.match(/img[^\>]+src=['"]images\/misc\/2a436\.test\.png["']/));
     assert.ok(changed.match(/img[^\>]+src=['"]\/\/images\/test\.png["']/));
@@ -115,7 +114,6 @@ describe('usemin', function () {
 
 
     var changed = grunt.file.read('build/css/style.css');
-
     // Check replace has performed its duty
     assert.ok(changed.match(/url\(\"\.\.\/\.\.\/images\/23012\.test\.png\"/));
   });
@@ -182,6 +180,22 @@ describe('usemin', function () {
     assert.ok(changed.match(/img[^\>]+src=['"]images\/misc\/2a436\.test\.png["']/));
     assert.ok(changed.match(/img[^\>]+src=['"]\/\/images\/test\.png["']/));
     assert.ok(changed.match(/img[^\>]+src=['"]\/images\/23012\.test\.png["']/));
+  });
+
+  it('should consider that data-main point to a JS file', function () {
+    grunt.file.mkdir('scripts');
+    grunt.file.write('scripts/23012.main.js', 'foo');
+    grunt.log.muted = true;
+    grunt.config.init();
+    grunt.config('usemin', {html: 'index.html'});
+    grunt.file.copy(path.join(__dirname, 'fixtures/usemin.html'), 'index.html');
+    grunt.task.run('usemin');
+    grunt.task.start();
+
+    var changed = grunt.file.read('index.html');
+
+    // Check replace has performed its duty
+    assert.ok(changed.match(/data-main="scripts\/23012.main.js"/));
   });
 
 


### PR DESCRIPTION
`data-main` parameter in a `script` tag for `requirejs` is somewhat not givng the suffix (for example: `data-main="main"`)
This leads to `main` not being replaced by its revved version.
