### PR TITLE
Fix backslashes not getting replaced on Windows

### DIFF
--- a/lib/htmlprocessor.js
+++ b/lib/htmlprocessor.js
@@ -141,7 +141,7 @@ HTMLProcessor.prototype.replaceWith = function replaceWith(block) {
   }
 
   // fix windows style paths. Dirty but works.
-  dest = dest.replace('\\', '/');
+  dest = dest.replace(/\\/g, '/');
 
   if (block.type === 'css') {
     result = block.indent + '<link rel="stylesheet" href="' + dest + '">';


### PR DESCRIPTION
The current fix for replacing backslashes with forward slashes in paths on Windows doesn't work. This fixes it.
