### PR TITLE
Fix replacing data-main when using require.js

### DIFF
--- a/lib/htmlprocessor.js
+++ b/lib/htmlprocessor.js
@@ -91,6 +91,7 @@ var getBlocks = function (dir, content) {
           last.requirejs.dest = last.dest;
           last.requirejs.baseUrl = path.join(dir, path.dirname(main[1]));
           last.requirejs.name = path.basename(main[1]);
+          last.requirejs.src = last.src.pop();
           last.src.push(last.dest);
         }
       }
@@ -131,6 +132,7 @@ HTMLProcessor.prototype.log = function log(msg) {
 //
 HTMLProcessor.prototype.replaceWith = function replaceWith(block) {
   var result;
+  var backslash = /\\/g;
 
   // Determine the relative path from the destination to the source
   // file
@@ -141,10 +143,20 @@ HTMLProcessor.prototype.replaceWith = function replaceWith(block) {
   }
 
   // fix windows style paths. Dirty but works.
-  dest = dest.replace(/\\/g, '/');
+  dest = dest.replace(backslash, '/');
 
   if (block.type === 'css') {
     result = block.indent + '<link rel="stylesheet" href="' + dest + '">';
+  } else if (block.requirejs !== undefined) {
+    var dataMain = path.relative(this.relativePath, block.requirejs.dest);
+    dataMain = dataMain.replace(backslash, '/');
+    var requireSrc = path.relative(this.relativePath, block.requirejs.src);
+    requireSrc = requireSrc.replace(backslash, '/');
+    if (block.startFromRoot) {
+      dataMain = '/' + dataMain;
+      requireSrc = '/' + requireSrc;
+    }
+    result = block.indent + '<script data-main="' + dataMain + '" src="' + requireSrc + '"><\/script>';
   } else if (block.type === 'js') {
     result = block.indent + '<script src="' + dest + '"><\/script>';
   } else {

--- a/test/test-usemin.js
+++ b/test/test-usemin.js
@@ -90,10 +90,11 @@ describe('usemin', function () {
 
 
     var changed = grunt.file.read('build/index.html');
+    console.log('should take into account original file location when replacing ' + changed);
 
     // Check replace has performed its duty
     assert.ok(changed.match(/<script src=\"scripts\/foo\.js\"><\/script>/));
-    assert.ok(changed.match(/<script src=\"scripts\/amd-app\.js\"><\/script>/));
+    assert.ok(changed.match(/<script data-main=\"scripts\/amd-app.js\" src=\"scripts\/vendor\/require.js\"><\/script>/));
     assert.ok(changed.match(/img[^\>]+src=['"]images\/23012\.test\.png["']/));
     assert.ok(changed.match(/img[^\>]+src=['"]images\/misc\/2a436\.test\.png["']/));
     assert.ok(changed.match(/img[^\>]+src=['"]\/\/images\/test\.png["']/));
@@ -172,10 +173,11 @@ describe('usemin', function () {
 
 
     var changed = grunt.file.read('index.html');
+    console.log('should limit search to selected directories when asked to ' + changed);
 
     // Check replace has performed its duty
     assert.ok(changed.match(/<script src=\"scripts\/foo\.js\"><\/script>/));
-    assert.ok(changed.match(/<script src=\"scripts\/amd-app\.js\"><\/script>/));
+    assert.ok(changed.match(/<script data-main=\"scripts\/amd-app.js\" src=\"scripts\/vendor\/require.js\"><\/script>/));
     assert.ok(changed.match(/img[^\>]+src=['"]images\/23012\.test\.png["']/));
     assert.ok(changed.match(/img[^\>]+src=['"]images\/misc\/2a436\.test\.png["']/));
     assert.ok(changed.match(/img[^\>]+src=['"]\/\/images\/test\.png["']/));
@@ -193,6 +195,7 @@ describe('usemin', function () {
     grunt.task.start();
 
     var changed = grunt.file.read('index.html');
+    console.log('should consider that data-main point to a JS file ' + changed);
 
     // Check replace has performed its duty
     assert.ok(changed.match(/data-main="scripts\/23012.main.js"/));


### PR DESCRIPTION
Code change with tests for cases where we are using a data-main attribute for a require.js application. This ensures that the data-main tag is preserved and updated with the specified js file.
