### PR TITLE
Implement block-alternate origin path

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,12 +30,13 @@ A special task which uses the build block HTML comments in markup to get back th
 Custom HTML "block" comments are provided as an API for interacting with the build script. These comments adhere to the following pattern:
 
 ```html
-<!-- build:<type> <path> -->
+<!-- build:<type>(alternate search path) <path> -->
 ... HTML Markup, list of script / link tags.
 <!-- endbuild -->
 ```
 
 - **type**: either `js` or `css`
+- ** alternate search path **: (optional) By default the input files are relative to the treated file. Alternate search path allow to change that
 - **path**: the file path of the optimized file, the target output
 
 An example of this in completed form can be seen below:

--- a/lib/htmlprocessor.js
+++ b/lib/htmlprocessor.js
@@ -34,8 +34,16 @@ var path = require('path');
 // then dest will equal foo/css/site.css (note missing trailing /)
 //
 var getBlocks = function (dest, dir, content) {
-  // start build pattern --> <!-- build:[target] output -->
-  var regbuild = /<!--\s*build:(\w+)\s*([^\s]+)\s*-->/;
+  // start build pattern: will match
+  //  * <!-- build:[target] output --> 
+  //  * <!-- build:[target](alternate search path) output --> 
+  // The following matching param are set when there's match
+  //   * 0 : the whole matched expression
+  //   * 1 : the target (ie. type)
+  //   * 2 : the alternate search path
+  //   * 3 : the output
+  //
+  var regbuild = /<!--\s*build:(\w+)(?:\(([^\)]+)\))?\s*([^\s]+)\s*-->/;
   // end build pattern -- <!-- endbuild -->
   var regend = /<!--\s*endbuild\s*-->/;
 
@@ -43,6 +51,8 @@ var getBlocks = function (dest, dir, content) {
     block = false,
     sections = [],
     last;
+
+  var originDir = dir;
 
   lines.forEach(function (l) {
     var indent = (l.match(/^\s*/) || [])[0];
@@ -54,13 +64,17 @@ var getBlocks = function (dest, dir, content) {
     if (build) {
       block = true;
       // Handle absolute path (i.e. with respect to the server root)
-      if (build[2][0] === '/') {
+      if (build[3][0] === '/') {
         startFromRoot = true;
-        build[2] = build[2].substr(1);
+        build[3] = build[3].substr(1);
+      }
+      if (build[2]) {
+        // Alternate search path
+        originDir = build[2];
       }
       last = {
         type: build[1],
-        dest: path.join(dest, build[2]),
+        dest: path.join(dest, build[3]),
         startFromRoot: startFromRoot,
         indent: indent,
         src: [],
@@ -73,12 +87,13 @@ var getBlocks = function (dest, dir, content) {
       last.raw.push(l);
       sections.push(last);
       block = false;
+      originDir = dir;
     }
 
     if (block && last) {
       var asset = l.match(/(href|src)=["']([^'"]+)["']/);
       if (asset && asset[2]) {
-        last.src.push(path.join(dir, asset[2]));
+        last.src.push(path.join(originDir, asset[2]));
         // RequireJS uses a data-main attribute on the script tag to tell it
         // to load up the main entry point of the amp app
         //
@@ -89,7 +104,7 @@ var getBlocks = function (dest, dir, content) {
         if (main) {
           last.requirejs = last.requirejs || {};
           last.requirejs.dest = last.dest;
-          last.requirejs.baseUrl = path.join(dir, path.dirname(main[1]));
+          last.requirejs.baseUrl = path.join(originDir, path.dirname(main[1]));
           last.requirejs.name = path.basename(main[1]);
           last.requirejs.src = last.src.pop();
           last.requirejs.srcDest = path.join(dest, 'scripts/vendor/require.js');

--- a/test/fixtures/alternate_search_path.html
+++ b/test/fixtures/alternate_search_path.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+    <head>
+        <link rel="stylesheet" href="styles/main.css">
+        <script src="scripts/vendor/modernizr.min.js"></script>
+    </head>
+    <body>
+
+    <!-- build:js(build) scripts/foo.js -->
+    <script src="scripts/bar.js"></script>
+    <script src="scripts/baz.js"></script>
+    <!-- endbuild -->
+
+    <!-- build:js scripts/amd-app.js -->
+    <script data-main="scripts/main" src="scripts/vendor/require.js"></script>
+    <!-- endbuild -->
+
+    <img src="images/test.png">
+    <img src="images/misc/test.png">
+    <img src="//images/test.png">
+    <img src="/images/test.png">
+    <a href="http://foo/bar"></a><a href="ftp://bar"></a><a href="images/test.png"></a><a href="/images/test.png"></a><a href="#local"></a>
+</body>
+</html>

--- a/test/test-htmlprocessor.js
+++ b/test/test-htmlprocessor.js
@@ -55,6 +55,26 @@ describe('htmlprocessor', function () {
     assert.equal(1, b3.src.length); // requirejs has been added also
   });
 
+  it('should also detect block that use alternate search dir', function () {
+    var filename = __dirname + '/fixtures/alternate_search_path.html';
+    var htmlcontent =  grunt.file.read(filename);
+    var hp = new HTMLProcessor(path.dirname(filename), '', htmlcontent, 3);
+    assert.equal(2, hp.blocks.length);
+    var b1 = hp.blocks[0];
+    var b2 = hp.blocks[1];
+
+    assert.equal(4, b1.raw.length);
+    assert.equal('js', b1.type);
+    assert.equal(2, b1.src.length);
+    assert.equal(b1.src[0], 'build/scripts/bar.js');
+    assert.equal(b1.src[1], 'build/scripts/baz.js');
+    assert.equal(3, b2.raw.length);
+    assert.equal('js', b2.type);
+
+    assert.equal(2, b1.src.length);
+  });
+
+
   it('should detect and handle the usage on RequireJS in blocks', function () {
     var htmlcontent = '<!-- build:js scripts/amd-app.js -->\n' +
     '<script data-main="scripts/main" src="scripts/vendor/require.js"></script>\n' +

--- a/test/test-usemin.js
+++ b/test/test-usemin.js
@@ -251,6 +251,25 @@ describe('usemin', function () {
       assert.equal(uglify['scripts/plugins.js'], 'scripts/plugins.js');
     });
 
+    it('should use alternate search dir if asked to', function() {
+      grunt.log.muted = true;
+      grunt.config.init();
+      grunt.config('useminPrepare', {html: 'index.html'});
+      grunt.file.copy(path.join(__dirname, 'fixtures/alternate_search_path.html'), 'index.html');
+      grunt.task.run('useminPrepare');
+      grunt.task.start();
+
+      var concat = grunt.config('concat');
+      assert.ok(concat);
+      assert.ok(concat['scripts/foo.js']);
+      assert.equal(concat['scripts/foo.js'].length, 2);
+      assert.equal(concat['scripts/foo.js'][0], 'build/scripts/bar.js');
+      assert.equal(concat['scripts/foo.js'][1], 'build/scripts/baz.js');
+
+      var uglify = grunt.config('uglify');
+      assert.equal(uglify['scripts/foo.js'], 'scripts/foo.js');
+    });
+
     it('should update all requirejs multitask configs setting name and output', function () {
       grunt.log.muted = true;
       grunt.config.init();
@@ -285,7 +304,7 @@ describe('usemin', function () {
     });
 
     it('should handle correctly files in subdir (requirejs)', function () {
-      grunt.log.muted = false;
+      grunt.log.muted = true;
       grunt.config.init();
       grunt.config('useminPrepare', {html: 'app/index.html'});
       grunt.config('requirejs', {


### PR DESCRIPTION
This is fixing #63 by adding a way to alternate, at block-level, the origin path, when preparing concat and uglify config.

Usually, when something like that is specified in, let's say `app.index.html`:

```
        <!-- build:js scripts/main.js -->
        <script src="scripts/foo.js"></script>
        <script src="scripts/bar.js"></script>
        <!-- endbuild -->
```

`foo.js` and `bar.js` are searched relatively to the file (i.e. uglify and concant config are trying to get file from `app/scripts`).

By specifying an alternate directory (for example `.tmp`), we can change that:

```
        <!-- build:js(.tmp) scripts/main.js -->
        <script src="scripts/foo.js"></script>
        <script src="scripts/bar.js"></script>
        <!-- endbuild -->
```

foo.js`and`bar.js`are searched relatively to the`.tmp`directory (i.e.`.tmp/scripts/foo.js`).
