### PR TITLE
Convert concat blocks to non simple form

### DIFF
--- a/tasks/usemin.js
+++ b/tasks/usemin.js
@@ -148,7 +148,15 @@ module.exports = function (grunt) {
           .writeln('    - ' + grunt.log.wordlist(block.src, { separator: '\n    - ' }));
 
         // update concat config for this block
-        concat[block.dest] = block.src;
+        if (block.dest.match(/^_/)) {
+          // grunt does not allow tasks with _, so conver to complex method
+          concat[block.dest.replace('_', '')] = {
+            src: block.src,
+            dest: block.dest
+          };
+        } else {
+          concat[block.dest] = block.src;
+        }
         grunt.config('concat', concat);
 
         // update requirejs config as well, as during path lookup we might have

--- a/test/fixtures/underscore_dest.html
+++ b/test/fixtures/underscore_dest.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<!--[if lt IE 7]>      <html class="no-js lt-ie9 lt-ie8 lt-ie7"> <![endif]-->
+<!--[if IE 7]>         <html class="no-js lt-ie9 lt-ie8"> <![endif]-->
+<!--[if IE 8]>         <html class="no-js lt-ie9"> <![endif]-->
+<!--[if gt IE 8]><!--> <html class="no-js"> <!--<![endif]-->
+    <head>
+        <meta charset="utf-8">
+        <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+        <title></title>
+        <meta name="description" content="">
+        <meta name="viewport" content="width=device-width">
+
+        <!-- Place favicon.ico and apple-touch-icon.png in the root directory -->
+
+
+        <!-- build:css _styles/main.min.css -->
+        <link rel="stylesheet" href="styles/main.css">
+        <!-- endbuild -->
+    </head>
+    <body>
+      <div>Very Basic HTML</div>
+    </body>
+</html>

--- a/test/test-usemin.js
+++ b/test/test-usemin.js
@@ -411,5 +411,22 @@ describe('usemin', function () {
       assert.equal(uglify['scripts/amd-app.js'], 'scripts/amd-app.js');
       assert.equal(uglify['scripts/plugins.js'], 'scripts/plugins.js');
     });
+
+    it('should not fail when output directory starts with _', function () {
+      grunt.log.muted = true;
+      grunt.config.init();
+      grunt.config('useminPrepare', {html: 'index.html'});
+      grunt.file.copy(path.join(__dirname, 'fixtures/underscore_dest.html'), 'index.html');
+      grunt.task.run('useminPrepare');
+      grunt.task.start();
+
+      var concat = grunt.config('concat');
+      assert.ok(concat);
+      Object.keys(concat).forEach(function (taskName) {
+        assert.ok(!taskName.match(/^_/));
+      });
+      assert.ok(concat['styles/main.min.css']);
+      assert.equal(concat['styles/main.min.css'].dest, '_styles/main.min.css');
+    });
   });
 });


### PR DESCRIPTION
I'm working on a couchdb app. They need files outputted to _attachments directory. I found that after setting up grunt-usemin I couldn't get "grunt useminPrepare concat" to work properly.

After a lot of digging. I found documentation that grunt ignores sub/multi tasks starting with _ in them. This means outputting to the _attachment directory fails.

So simple patch to prevent _ in the task name by defining the more complex block.
