### PR TITLE
Add "grunt test" support

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -18,5 +18,19 @@ module.exports = function (grunt) {
 
   grunt.loadTasks('tasks');
 
-  grunt.registerTask('default', ['jshint']);
+  grunt.registerTask('test', 'Run tests', function () {
+    var done = this.async();
+    var spawnOpts = {
+      cmd: 'node_modules/mocha/bin/mocha',
+      args: grunt.file.expand('test/test-*.js')
+    };
+    grunt.util.spawn(spawnOpts, function(err, res, code) {
+      grunt.log.write(res.stdout);
+      if (code) {
+        throw res.stderr;
+      }
+      done();
+    });
+  });
+  grunt.registerTask('default', ['jshint','test']);
 };


### PR DESCRIPTION
Simple test running for cli mocha.

I tried using yaymukund/grunt-simple-mocha but since that runs in the same process as grunt, the unit tests will have all the Gruntfile.js values setup and breaks the tests.

So this runs the same cli that travis does. 

This is mostly to combine with #74 so travis-ci can run "grunt jshint test" and catch both types of errors.
