### PR TITLE
Fix files not being reved even though rooted

### DIFF
--- a/lib/revvedfinder.js
+++ b/lib/revvedfinder.js
@@ -56,6 +56,7 @@ RevvedFinder.prototype.find = function find(ofile, basedir) {
     if (ofile.match(/^\//)) {
       file = ofile.substr(1);
       startAtRoot = true;
+      basedir = '.';
     }
 
     // Our filename

--- a/test/test-revvedfinder.js
+++ b/test/test-revvedfinder.js
@@ -71,6 +71,12 @@ describe('RevvedFinder', function () {
       });
       assert.equal('/1234.foo.png', rf.find('/foo.png', '.'));
     });
+    it('should rev files starting at root regardless of file location', function () {
+      var rf = new RevvedFinder(function () {
+        return ['1234.foo.png'];
+      });
+      assert.equal('/1234.foo.png', rf.find('/foo.png', 'bar/baz'));
+    });
     it('should only looked at revved files', function () {
       var rf = new RevvedFinder(function () {
         return ['bar-fred.html'];


### PR DESCRIPTION
When revved files are rooted the basedir should also be rooted, so it can match them.

For example:
- images/foo.jpg
- templates/index.html with  `<img src="/images/foo.jpg">`

Currently this won't be revved as it looks for the image in templates/images/.

This patch should fix that, but I might have missed something
