### PR TITLE
Add support for font related browser hacks.

### DIFF
--- a/lib/cssprocessor.js
+++ b/lib/cssprocessor.js
@@ -32,7 +32,7 @@ CSSProcessor.prototype.process = function process() {
     var self = this;
     // Replace reference to images with the actual name of the optimized image
     this.log('Update the CSS with new img filenames');
-    return this.content.replace(/url\(\s*['"]?([^'"\)]+)['"]?\s*\)/gm, function (match, src) {
+    return this.content.replace(/url\(\s*['"]?([^'"\)#?]+)(?:[#?](?:[^'"\)]*))?['"]?\s*\)/gm, function (match, src) {
       // Consider reference from site root
       var file = self.revvedfinder.find(src, self.filepath);
       var res = match.replace(src, file);

--- a/test/test-cssprocessor.js
+++ b/test/test-cssprocessor.js
@@ -15,6 +15,7 @@ describe('cssprocessor', function () {
       'images/pic.png': 'images/2123.pic.png',
       '/images/pic.png': '/images/2123.pic.png',
       '../../images/pic.png': '../../images/2123.pic.png',
+      'fonts/awesome-font.svg': 'fonts/2123.awesome-font.svg',
     };
     var revvedfinder = {
       find: function (s) {
@@ -54,6 +55,20 @@ describe('cssprocessor', function () {
       var content = 'background-image:url(../../images/pic.png);';
       var cp = new CSSProcessor('', 'build/css', content, revvedfinder);
       var awaited = 'background-image:url(../../images/2123.pic.png);';
+      assert.equal(awaited, cp.process());
+    });
+
+    it('should support hashes in urls', function () {
+      var content = 'background-image:url(fonts/awesome-font.svg#browser-hack);';
+      var cp = new CSSProcessor('', 'build/css', content, revvedfinder);
+      var awaited = 'background-image:url(fonts/2123.awesome-font.svg#browser-hack);';
+      assert.equal(awaited, cp.process());
+    });
+
+    it('should support hashes in urls', function () {
+      var content = 'background-image:url(fonts/awesome-font.svg?#iefix);';
+      var cp = new CSSProcessor('', 'build/css', content, revvedfinder);
+      var awaited = 'background-image:url(fonts/2123.awesome-font.svg?#iefix);';
       assert.equal(awaited, cp.process());
     });
   });


### PR DESCRIPTION
While trying to use font-awesome via bower, I was stumped by usemin's total lack of substitution of this font on the final minified css file.

This is due to the fonts referenced by awesome-font's stylesheets being:

``` css
    @font-face {
      font-family: 'FontAwesome';
      src: url('../font/fontawesome-webfont.eot?v=3.0.1');
      src: url('../font/fontawesome-webfont.eot?#iefix&v=3.0.1') format('embedded-opentype'),
           url('../font/fontawesome-webfont.woff?v=3.0.1') format('woff'),
           url('../font/fontawesome-webfont.ttf?v=3.0.1') format('truetype');
      font-weight: normal;
      font-style: normal;
    }
```

While investigating this I've also bumped on other hacks like this:

``` css
    @font-face {
        font-family: 'JinkyRegular';
        src: url(fonts/jinky/JINKY-webfont.eot);
        src: url(fonts/jinky/JINKY-webfont.eot?#iefix) format('embedded-opentype'),
             url(fonts/jinky/JINKY-webfont.woff) format('woff'),
             url(fonts/jinky/JINKY-webfont.ttf) format('truetype'),
             url(fonts/jinky/JINKY-webfont.svg#JinkyRegular) format('svg');
        font-weight: normal;
        font-style: normal;
    }
```

So, this patch adds support for both `?` and `#` as file name delimiters. It includes tests.

I've already signed the CLA (and have some very very small patches accepted into V8).
