### PR TITLE
Handle absolute script paths properly in files that aren't in the root of the repository.

### DIFF
--- a/lib/htmlprocessor.js
+++ b/lib/htmlprocessor.js
@@ -93,7 +93,11 @@ var getBlocks = function (dest, dir, content) {
     if (block && last) {
       var asset = l.match(/(href|src)=["']([^'"]+)["']/);
       if (asset && asset[2]) {
-        last.src.push(path.join(originDir, asset[2]));
+        if (asset[2].indexOf('/') === 0) {
+          last.src.push(path.join('.', asset[2]));
+        } else {
+          last.src.push(path.join(originDir, asset[2]));
+        }
         // RequireJS uses a data-main attribute on the script tag to tell it
         // to load up the main entry point of the amp app
         //


### PR DESCRIPTION
I believe this solves the problem I described at the end of https://github.com/yeoman/grunt-usemin/issues/12
