### PR TITLE
Add a test for the Windows-style paths fix

### DIFF
--- a/test/test-htmlprocessor.js
+++ b/test/test-htmlprocessor.js
@@ -136,6 +136,15 @@ describe('htmlprocessor', function () {
   });
 
   describe('replaceWith', function () {
+    it('should handle Windows-style paths', function () {
+      var htmlcontent = '<!-- build:js bar\\foo.js -->\n' +
+      '<script src="foo\\bar.js"></script>\n' +
+      '<!-- endbuild -->';
+      var hp = new HTMLProcessor('', '', htmlcontent, 3);
+      var replacestring = hp.replaceWith(hp.blocks[0]);
+      assert.equal('<script src="bar/foo.js"></script>', replacestring);
+    });
+
     it('should return a string that will replace the furnished block (JS)', function () {
       var htmlcontent = '  <!-- build:js foo.js -->   <script src="scripts/bar.js"></script>\n  <script src="baz.js"></script>\n  <!-- endbuild -->\n';
       var hp = new HTMLProcessor('', '', htmlcontent, 3);


### PR DESCRIPTION
The `replaceWith` method includes a dirty fix for Windows-style paths
appearing in the HTML build directives. This adds a test for that fix.
