### PR TITLE
Add specific test for preserving indentation

### DIFF
--- a/test/test-htmlprocessor.js
+++ b/test/test-htmlprocessor.js
@@ -36,6 +36,14 @@ describe('htmlprocessor', function () {
     assert.equal('  ', hp.blocks[0].indent);
   });
 
+  it('should return the correct indentation', function () {
+    var htmlcontent = '  <!-- build:css foo.css -->\n' +
+    '  <link rel="stylesheet" href="foo.css">\n' +
+    '  <!-- endbuild -->\n';
+    var hp = new HTMLProcessor('', '', htmlcontent, 3);
+    assert.equal('  ', hp.blocks[0].indent);
+  });
+
   it('should return the right number of blocks with the right number of lines', function () {
     var filename = __dirname + '/fixtures/usemin.html';
     var htmlcontent =  grunt.file.read(filename);


### PR DESCRIPTION
There's no specific test for this. In combination with the fixture normalization PR (removal of indentation from tests not checking for indentation), this should result in just a couple of test failures if indentation-preservation isn't working...rather than most of the test suite failing.
