### PR TITLE
Change linting options to allow function hoisting

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -14,7 +14,7 @@
   "eqeqeq": true,
   "immed": true,
   "indent": 2,
-  "latedef": true,
+  "latedef": false,
   "newcap": true,
   "noarg": true,
   "quotmark": "single",


### PR DESCRIPTION
Change `latedef` to `false` so that jsHint doesn't complain about function hoisting.

At some point it would be nice to rewrite some of the library code to make use of function hoisting. Can't do that while jsHint is complaining about it.
