### PR TITLE
mainConfigFile setting should not be overwritten if already present in requirejs config

### DIFF
--- a/tasks/usemin.js
+++ b/tasks/usemin.js
@@ -174,13 +174,13 @@ module.exports = function (grunt) {
                 options.name = options.name || block.requirejs.name;
                 options.out = options.out || block.requirejs.dest;
                 options.baseUrl = options.baseUrl || block.requirejs.baseUrl;
-                options.mainConfigFile = path.join(options.baseUrl, options.name) + '.js';
+                options.mainConfigFile = options.mainConfigFile || path.join(options.baseUrl, options.name) + '.js';
               } else {
                 task.options = {
                   name: block.requirejs.name,
                   out: block.requirejs.dest,
                   baseUrl: block.requirejs.baseUrl,
-                  mainConfigFile: path.join(block.requirejs.baseUrl, block.requirejs.name) + '.js'
+                  mainConfigFile: block.requirejs.mainConfigFile || path.join(block.requirejs.baseUrl, block.requirejs.name) + '.js'
                 };
               }
             }

--- a/test/test-usemin.js
+++ b/test/test-usemin.js
@@ -318,6 +318,26 @@ describe('usemin', function () {
       // assert.equal(requirejs.task2.options.mainConfigFile, 'base');
     });
 
+    it('should not ovewrite predefined mainConfigFile setting', function () {
+      grunt.log.muted = true;
+      grunt.config.init();
+      grunt.config('useminPrepare', {html: 'index.html'});
+      grunt.config('requirejs', {
+        task: {
+          options: {
+            baseUrl: 'base',
+            mainConfigFile: 'scripts/bootstrap.js'
+          }
+        }
+      });
+      grunt.file.copy(path.join(__dirname, 'fixtures/usemin.html'), 'index.html');
+      grunt.task.run('useminPrepare');
+      grunt.task.start();
+
+      var requirejs = grunt.config('requirejs');
+      assert.equal(requirejs.task.options.mainConfigFile, 'scripts/bootstrap.js');
+    });
+
     it('should handle correctly files in subdir (requirejs)', function () {
       grunt.log.muted = true;
       grunt.config.init();


### PR DESCRIPTION
This allows building multipage projects with only one bootstrap file. Fixes #72 
