### PR TITLE
Preserve media attribute

### DIFF
--- a/lib/htmlprocessor.js
+++ b/lib/htmlprocessor.js
@@ -117,6 +117,12 @@ var getBlocks = function (dest, dir, content) {
           last.requirejs.srcDest = path.join(dest, last.requirejs.origScript);
           last.src.push(last.dest);
         }
+
+        // preserve media attribute
+        var media = l.match(/media=['"]([^'"]+)['"]/);
+        if ( media ) {
+          last.media = media[1];
+        }
       }
       last.raw.push(l);
     }
@@ -172,7 +178,8 @@ HTMLProcessor.prototype.replaceWith = function replaceWith(block) {
   dest = dest.replace(backslash, '/');
 
   if (block.type === 'css') {
-    result = block.indent + '<link rel="stylesheet" href="' + dest + '">';
+    var media = block.media ? ' media="' + block.media + '"' : '';
+    result = block.indent + '<link rel="stylesheet" href="' + dest + '"' + media + '>';
   } else if (block.requirejs !== undefined) {
     var dataMain = path.relative(this.relativeSrc, block.requirejs.dest);
     dataMain = dataMain.replace(backslash, '/');

--- a/test/test-htmlprocessor.js
+++ b/test/test-htmlprocessor.js
@@ -99,6 +99,16 @@ describe('htmlprocessor', function () {
     assert.equal('main', hp.blocks[0].requirejs.name);
   });
 
+  it('should detect media attribute', function() {
+    var htmlcontent = '<!-- build:css foo.css -->\n' +
+    '<link rel="stylesheet" href="foo.css" media="(min-width:980px)">\n' +
+    '<!-- endbuild -->\n';
+    var hp = new HTMLProcessor('', '', htmlcontent, 3);
+    assert.equal(1, hp.blocks.length);
+    assert.ok(hp.blocks[0].media);
+    assert.equal('(min-width:980px)', hp.blocks[0].media);
+  });
+
   it('should take into consideration path of the source file', function () {
     var htmlcontent = '<!-- build:css bar/foo.css -->\n' +
     '<link rel="stylesheet" href="bar.css">\n' +
@@ -182,6 +192,15 @@ describe('htmlprocessor', function () {
       var hp = new HTMLProcessor('', '', htmlcontent, 3);
       var replacestring = hp.replaceWith(hp.blocks[0]);
       assert.equal(replacestring, '<link rel="stylesheet" href="foo.css">');
+    });
+
+    it('should preserve media attribue (CSS)', function () {
+      var htmlcontent = '<!-- build:css foo.css -->\n' +
+      '<link rel="stylesheet" href="bar.css" media="(min-width:980px)">\n' +
+      '<!-- endbuild -->\n';
+      var hp = new HTMLProcessor('', '', htmlcontent, 3);
+      var replacestring = hp.replaceWith(hp.blocks[0]);
+      assert.equal(replacestring, '<link rel="stylesheet" href="foo.css" media="(min-width:980px)">');
     });
 
     it('should replace with a path relative to the file', function () {


### PR DESCRIPTION
I create responsive designs by splitting mobile and desktop css entirely and using the `media` attribute of the stylesheet links instead of @media rules in the css. So the css part of my index.html usually looks like this:

``` css
<!-- build:css(.tmp) styles/style.css -->
<link href="components/normalize-css/normalize.css" rel="stylesheet" type="text/css" />
<link href="styles/index.css" rel="stylesheet" type="text/css" />
<!-- endbuild -->

<!-- build:css(.tmp) styles/mobile.css -->
<link rel="stylesheet" href="styles/mobile.css"  media="(max-width:979px)" />
<!-- endbuild -->
<!-- build:css(.tmp) styles/desktop.css -->
<link rel="stylesheet" href="styles/desktop.css" media="(min-width:980px)" />
<!-- endbuild -->
<!--[if lte IE 8 & (!IEMobile)]>
<link rel="stylesheet" href="/styles/desktop.css" />
<![endif]-->
```

I need grunt-usemin to preserve the media attribute of the mobile.css and desktop.css links.

This patch does just that. Logically, one block is required per media attribute.
