### PR TITLE
Add Jade comments detection support.

### DIFF
--- a/lib/htmlprocessor.js
+++ b/lib/htmlprocessor.js
@@ -43,9 +43,9 @@ var getBlocks = function (dest, dir, content) {
   //   * 2 : the alternate search path
   //   * 3 : the output
   //
-  var regbuild = /<!--\s*build:(\w+)(?:\(([^\)]+)\))?\s*([^\s]+)\s*-->/;
+  var regbuild = /(?:<!--|\/\/)\s*build:(\w+)(?:\(([^\)]+)\))?\s*([^\s]+)\s*(?:-->)?/;
   // end build pattern -- <!-- endbuild -->
-  var regend = /<!--\s*endbuild\s*-->/;
+  var regend = /(?:<!--|\/\/)\s*endbuild\s*(?:-->)?/;
 
   var lines = content.replace(/\r\n/g, '\n').split(/\n/),
     block = false,

--- a/test/test-htmlprocessor.js
+++ b/test/test-htmlprocessor.js
@@ -39,6 +39,19 @@ describe('htmlprocessor', function () {
     assert.equal('', hp.blocks[0].indent);
   });
 
+  it('should detect jade comments', function () {
+    var htmlcontent = '// build:css foo.css\n' +
+    '<link rel="stylesheet" href="bar.css">\n\n' +
+    '<link rel="stylesheet" href="foo.css">\n' +
+    '// endbuild\n';
+    var hp = new HTMLProcessor('', '', htmlcontent, 3);
+    assert.equal(1, hp.blocks.length);
+    assert.equal('foo.css', hp.blocks[0].dest);
+    assert.equal(5, hp.blocks[0].raw.length);
+    assert.equal(2, hp.blocks[0].src.length);
+    assert.equal('', hp.blocks[0].indent);
+  });
+
   it('should return the correct indentation', function () {
     var htmlcontent = '  <!-- build:css foo.css -->\n' +
     '  <link rel="stylesheet" href="foo.css">\n' +


### PR DESCRIPTION
[Jade](https://github.com/visionmedia/jade) is a template engine that
can be used to build layouts in webapps. It uses a specific comments
style `//`. Usemin can detect this kind of comments directly in your
templates.
