### PR TITLE
support for revved files with suffix/postfix naming

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -13,26 +13,16 @@ module.exports = function (grunt) {
         '!test/temp/**/*.js',
         '!test/fixtures/*.js'
       ]
+    },
+    mochacli: {
+      all: ['test/test-*.js']
     }
   });
 
   grunt.loadNpmTasks('grunt-contrib-jshint');
+  grunt.loadNpmTasks('grunt-mocha-cli');
 
   grunt.loadTasks('tasks');
 
-  grunt.registerTask('test', 'Run tests', function () {
-    var done = this.async();
-    var spawnOpts = {
-      cmd: 'node_modules/mocha/bin/mocha',
-      args: grunt.file.expand('test/test-*.js')
-    };
-    grunt.util.spawn(spawnOpts, function (err, res, code) {
-      grunt.log.write(res.stdout);
-      if (code) {
-        throw res.stderr;
-      }
-      done();
-    });
-  });
-  grunt.registerTask('default', ['jshint', 'test']);
+  grunt.registerTask('default', ['jshint', 'mochacli']);
 };

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ This asset search directories collection is by default set to the location of th
 ```
 By default `usemin` will look under `dist/html` for revved versions of:
 
-- `styles/main.css`: a revved version of `main.css` will be looked at under the `dist/html/styles` directory. For example a file `dist/html/styles/1234.main.css` will match (although `dist/html/1234.main.css` won't: the path of the referenced file is important)
+- `styles/main.css`: a revved version of `main.css` will be looked at under the `dist/html/styles` directory. For example a file `dist/html/styles/main.1234.css` will match (although `dist/html/main.1234.css` won't: the path of the referenced file is important)
 - `../images/test.png`: it basically means that a revved version of `test.png` will be looked for under the `dist/images` directory
 
 #### Example 2: file `dist/html/index.html` has the following content:
@@ -54,7 +54,7 @@ By default `usemin` will look under `dist/html` for revved versions of:
     <link rel="stylesheet" href="/styles/main.css">
     <img src="/images/test.png">
 ```
-By default `usemin` will look under `dist/html` for revved versions of `styles/main.css` and `images/test.png`. Now let's suppose our assets are scattered in `dist/assets`. By changing the asset search path list to `['dist/assets']`, the revved versions of the files will be looked under `dist/assets` (and thus, for example, `dist/assets/images/875487.tes.png` and `dist/assets/styles/98090.main.css`) will be found.
+By default `usemin` will look under `dist/html` for revved versions of `styles/main.css` and `images/test.png`. Now let's suppose our assets are scattered in `dist/assets`. By changing the asset search path list to `['dist/assets']`, the revved versions of the files will be looked under `dist/assets` (and thus, for example, `dist/assets/images/test.875487.png` and `dist/assets/styles/main.98090.css`) will be found.
 
 ### Options
 
@@ -353,8 +353,8 @@ Relative files references are also looked at from location of the examined file,
 
 ### usemin
 `usemin` target is replacing references to images, scrips, css, ... in the furnished files (html, css, ...). These references may be either absolute (i.e. `/images/foo.png`) or relative (i.e. `image/foo.png` or `../images/foo.png`).
-When the reference is absolute a set of asset search paths should be looked at under the destination directory (for example, using the previous example, and `searchpath` equal to `['assets']`, `usemin` would try to find either a revved version of the image of the image bellow the `assets` directory: for example `dest/assets/images/1223443.foo.png`).
-When the reference is relative, by default the referenced item is looked in the path relative *to the current file location* in the destination directory (e.g. with the preceding example, if the file is `build/bar/index.html`, then transformed `index.html` will be in `dist/bar`, and `usemin` will look for `dist/bar/../images/32323.foo.png`).
+When the reference is absolute a set of asset search paths should be looked at under the destination directory (for example, using the previous example, and `searchpath` equal to `['assets']`, `usemin` would try to find either a revved version of the image of the image bellow the `assets` directory: for example `dest/assets/images/foo.1223443.png`).
+When the reference is relative, by default the referenced item is looked in the path relative *to the current file location* in the destination directory (e.g. with the preceding example, if the file is `build/bar/index.html`, then transformed `index.html` will be in `dist/bar`, and `usemin` will look for `dist/bar/../images/foo.32323.png`).
 
 ## License
 

--- a/lib/revvedfinder.js
+++ b/lib/revvedfinder.js
@@ -33,8 +33,8 @@ RevvedFinder.prototype.getCandidatesFromMapping = function(file, searchPaths) {
       // We need to transform the actual file to a form that matches the one we received
       // For example if we received file 'foo/images/test.png' with searchPaths == ['dist'],
       // and found in mapping that 'dist/foo/images/test.png' has been renamed
-      // 'dist/foo/images/1234.test.png' by grunt-rev, then we need to return
-      // 'foo/images/1234.test.png'
+      // 'dist/foo/images/test.1234.png' by grunt-rev, then we need to return
+      // 'foo/images/test.1234.png'
       var cfile = path.basename(self.mapping[key]);
       candidates.push(dirname + '/' + cfile);
       debug('Found a candidate: %s/%s',dirname, cfile);
@@ -45,14 +45,22 @@ RevvedFinder.prototype.getCandidatesFromMapping = function(file, searchPaths) {
 }
 ;
 RevvedFinder.prototype.getCandidatesFromFS = function(file, searchPaths) {
-  var basename = path.basename(file);
+  var extname = path.extname(file);
+  var basename = path.basename(file, extname);
   var dirname = path.dirname(file);
-  var revvedRx = new RegExp('[0-9a-fA-F]+\\.' + regexpQuote(basename) + '$');
+  var revvedRx = new RegExp(regexpQuote(basename) + '\\.[0-9a-fA-F]+' + regexpQuote(extname) + '$');
   var candidates = [];
   var self = this;
 
   searchPaths.forEach(function(sp) {
-    var searchString = path.join(sp, dirname, '*.' + basename);
+    var searchString = path.join(sp, dirname, basename + '.*' + extname);
+
+    if (searchString.indexOf('#') === 0) {
+      // patterns starting with # are treated as comments by the glob implementation which returns undefined,
+      // which would cause an unhandled exception in self.expandfn below so the file is never written
+      return;
+    }
+
     debug('Looking for %s on disk', searchString);
 
     var files = self.expandfn(searchString);
@@ -86,7 +94,7 @@ RevvedFinder.prototype.getCandidatesFromFS = function(file, searchPaths) {
 // It should return an array of candidates that are in the same format as the
 // furnished file.
 // For example, when given file 'images/test.png', and searchPaths of ['dist']
-// the returned array should be something like ['images/1234.test.png']
+// the returned array should be something like ['images/test.1234.png']
 //
 RevvedFinder.prototype.getRevvedCandidates = function(file, searchPaths) {
   var candidates;
@@ -118,13 +126,13 @@ RevvedFinder.prototype.getRevvedCandidates = function(file, searchPaths) {
 //  |      + style.css
 //  + images
 //     |
-//     + 2123.pic.png
+//     + pic.2123.png
 //
 // and that somehow style.css is referencing '../../images/pic.png'
 // When called like that:
 //   revvedFinder.find('../../images/pic.png', 'build/css');
 // the function must return
-// '../../images/2123.pic.png'
+// '../../images/pic.2123.png'
 //
 // Note that +ofile+ should be a relative path to the looked for file
 // (i.e. if it's an absolue path -- starting with / -- or an external one -- containing :// -- then

--- a/package.json
+++ b/package.json
@@ -24,13 +24,13 @@
   "dependencies": {
     "lodash": "~1.0.1",
     "debug": "~0.7.2"
-    },
+  },
   "devDependencies": {
     "grunt": "~0.4.1",
-    "mocha": "~1.9.0",
     "mkdirp": "~0.3.5",
     "rimraf": "~2.1.4",
-    "grunt-contrib-jshint": "~0.4.1"
+    "grunt-contrib-jshint": "~0.4.1",
+    "grunt-mocha-cli": "~1.0.5"
   },
   "peerDependencies": {
     "grunt": "~0.4.0"

--- a/test/test-config-concat.js
+++ b/test/test-config-concat.js
@@ -1,6 +1,7 @@
 'use strict';
 var assert = require('assert');
 var concatConfig = require('../lib/config/concat.js');
+var path = require('path');
 
 var block = {
     type: 'js',
@@ -27,8 +28,8 @@ describe('Concat config write', function () {
   it('should use the input files correctly', function () {
     var ctx = { inDir: '.', inFiles: ['foo.js', 'bar.js', 'baz.js'], outDir: 'tmp/concat', outFiles: []};
     var cfg = concatConfig.createConfig( ctx, block );
-    assert.ok(cfg['tmp/concat/scripts/site.js']);
-    assert.deepEqual(cfg['tmp/concat/scripts/site.js'], ['foo.js', 'bar.js', 'baz.js']);
+    assert.ok(cfg[path.normalize('tmp/concat/scripts/site.js')]);
+    assert.deepEqual(cfg[path.normalize('tmp/concat/scripts/site.js')], ['foo.js', 'bar.js', 'baz.js']);
     assert.deepEqual(ctx.outFiles, ['scripts/site.js']);
   });
 });

--- a/test/test-config-requirejs.js
+++ b/test/test-config-requirejs.js
@@ -1,6 +1,7 @@
 'use strict';
 var assert = require('assert');
 var requirejsConfig = require('../lib/config/requirejs.js');
+var helpers = require('./helpers');
 
 var block = {
     type: 'js',
@@ -41,11 +42,11 @@ describe('Requirejs config write', function() {
   it('should use the input files correctly', function () {
     var ctx = { inDir: 'zzz', inFiles: ['foo.js'], outDir: 'tmp/requirejs', outFiles: []};
     var cfg = requirejsConfig.createConfig( ctx, block );
-    assert.deepEqual(cfg,{
+    assert.deepEqual(cfg,helpers.normalize({
       'default': {
         'options': { 'name': 'main', 'out': 'tmp/requirejs/scripts/amd-app.js', 'baseUrl': 'zzz/scripts', 'mainConfigFile': 'zzz/scripts/main.js'}
       }
-    });
+    }));
   });
 
   it('should do nothing if the block is not requirejs enabled', function() {
@@ -57,7 +58,7 @@ describe('Requirejs config write', function() {
   it('should add a .js when needed to mainConfigFile', function() {
     var ctx = { inDir: 'zzz', inFiles: ['foo.js'], outDir: 'tmp/requirejs', outFiles: []};
     var cfg = requirejsConfig.createConfig( ctx, block );
-    assert.equal(cfg['default'].options.mainConfigFile, 'zzz/scripts/main.js');
+    assert.equal(cfg['default'].options.mainConfigFile, helpers.normalize('zzz/scripts/main.js'));
   });
 
   it('should treat multi-config requirejs');

--- a/test/test-config-uglifyjs.js
+++ b/test/test-config-uglifyjs.js
@@ -1,6 +1,7 @@
 'use strict';
 var assert = require('assert');
 var uglifyjsConfig = require('../lib/config/uglifyjs.js');
+var path = require('path');
 
 var block = {
     type: 'js',
@@ -27,20 +28,20 @@ describe('Uglifyjs config write', function () {
   it('should use the input files correctly', function () {
     var ctx = { inDir: 'zzz', inFiles: ['foo.js', 'bar.js', 'baz.js'], outDir: 'tmp/uglifyjs', outFiles: []};
     var cfg = uglifyjsConfig.createConfig( ctx, block );
-    assert.ok(cfg['tmp/uglifyjs/foo.js']);
-    assert.deepEqual(cfg['tmp/uglifyjs/foo.js'], ['zzz/foo.js']);
-    assert.ok(cfg['tmp/uglifyjs/bar.js']);
-    assert.deepEqual(cfg['tmp/uglifyjs/bar.js'], ['zzz/bar.js']);
-    assert.ok(cfg['tmp/uglifyjs/baz.js']);
-    assert.deepEqual(cfg['tmp/uglifyjs/baz.js'], ['zzz/baz.js']);
+    assert.ok(cfg[path.normalize('tmp/uglifyjs/foo.js')]);
+    assert.deepEqual(cfg[path.normalize('tmp/uglifyjs/foo.js')], [path.normalize('zzz/foo.js')]);
+    assert.ok(cfg[path.normalize('tmp/uglifyjs/bar.js')]);
+    assert.deepEqual(cfg[path.normalize('tmp/uglifyjs/bar.js')], [path.normalize('zzz/bar.js')]);
+    assert.ok(cfg[path.normalize('tmp/uglifyjs/baz.js')]);
+    assert.deepEqual(cfg[path.normalize('tmp/uglifyjs/baz.js')], [path.normalize('zzz/baz.js')]);
     assert.deepEqual(ctx.outFiles, ['foo.js', 'bar.js', 'baz.js']);
   });
 
   it('should use the destination file if it is the laast step of the pipe.', function () {
     var ctx = { inDir: 'zzz', inFiles: ['foo.js', 'bar.js', 'baz.js'], outDir: 'dist', outFiles: [], last: true};
     var cfg = uglifyjsConfig.createConfig( ctx, block );
-    assert.ok(cfg['dist/scripts/site.js']);
-    assert.deepEqual(cfg['dist/scripts/site.js'], ['zzz/foo.js', 'zzz/bar.js', 'zzz/baz.js']);
+    assert.ok(cfg[path.normalize('dist/scripts/site.js')]);
+    assert.deepEqual(cfg[path.normalize('dist/scripts/site.js')], [path.normalize('zzz/foo.js'), path.normalize('zzz/bar.js'), path.normalize('zzz/baz.js')]);
     assert.deepEqual(ctx.outFiles, ['scripts/site.js']);
   });
 

--- a/test/test-config-writer.js
+++ b/test/test-config-writer.js
@@ -33,10 +33,10 @@ describe('ConfigWriter', function () {
       var file = helpers.createFile('foo', 'app', blocks);
       var c = new ConfigWriter( flow, [], {input: 'app', dest: 'dist', staging: '.tmp'} );
       var config = c.process(file);
-      assert.deepEqual(config, {
+      assert.deepEqual(config, helpers.normalize({
         'concat':{'.tmp/concat/scripts/site.js': ['app/foo.js', 'app/bar.js', 'app/baz.js']},
         'uglify': {'dist/scripts/site.js': ['.tmp/concat/scripts/site.js']}
-      });
+      }));
     });
 
     it('should have a configurable destination directory', function() {
@@ -45,10 +45,10 @@ describe('ConfigWriter', function () {
       var file = helpers.createFile('foo', 'app', blocks);
       var c = new ConfigWriter( flow, [], {input: 'app', dest: 'destination', staging: '.tmp'} );
       var config = c.process(file);
-      assert.deepEqual(config, {
+      assert.deepEqual(config, helpers.normalize({
         'concat':{'.tmp/concat/scripts/site.js': ['app/foo.js', 'app/bar.js', 'app/baz.js']},
         'uglify': {'destination/scripts/site.js': ['.tmp/concat/scripts/site.js']}
-      });
+      }));
     });
 
     it('should have a configurable staging directory', function() {
@@ -57,10 +57,10 @@ describe('ConfigWriter', function () {
       var file = helpers.createFile('foo', 'app', blocks);
       var c = new ConfigWriter( flow, [], {input: 'app', dest: 'dist', staging: 'staging'} );
       var config = c.process(file);
-      assert.deepEqual(config, {
+      assert.deepEqual(config, helpers.normalize({
         'concat': { 'staging/concat/scripts/site.js': ['app/foo.js', 'app/bar.js', 'app/baz.js'] },
         'uglify': { 'dist/scripts/site.js': ['staging/concat/scripts/site.js'] }
-      });
+      }));
     });
 
     it('should allow for single step flow', function() {
@@ -69,7 +69,7 @@ describe('ConfigWriter', function () {
       var file = helpers.createFile('foo', 'app', blocks);
       var c = new ConfigWriter( flow, [], {input: 'app', dest: 'dist', staging: 'staging'} );
       var config = c.process(file);
-      assert.deepEqual(config, {'uglify': {'dist/scripts/site.js': ['app/foo.js', 'app/bar.js', 'app/baz.js']}});
+      assert.deepEqual(config, helpers.normalize({'uglify': {'dist/scripts/site.js': ['app/foo.js', 'app/bar.js', 'app/baz.js']}}));
     });
 
     it('should rewrite the requirejs config if needed', function() {
@@ -79,7 +79,7 @@ describe('ConfigWriter', function () {
       var c = new ConfigWriter( flow, ['requirejs'], {input: 'app', dest: 'dist', staging: 'staging'} );
       var config = c.process(file);
 
-      assert.deepEqual(config, {
+      assert.deepEqual(config, helpers.normalize({
         'concat':{'staging/concat/scripts/amd-app.js': ['app/scripts/main.js']},
         'uglify': {'dist/scripts/amd-app.js': ['staging/concat/scripts/amd-app.js']},
         'requirejs': { 'default':
@@ -87,7 +87,7 @@ describe('ConfigWriter', function () {
             options: {name: 'main', out: 'dist/scripts/amd-app.js', baseUrl: 'app/scripts', mainConfigFile: 'app/scripts/main.js'}
           }
         }
-        });
+        }));
     });
 
     it('should allow for a configuration of the flow\'s step order', function() {
@@ -97,10 +97,10 @@ describe('ConfigWriter', function () {
       var c = new ConfigWriter( flow, [], {input: 'app', dest: 'dist', staging: 'staging'} );
       var config = c.process(file);
 
-      assert.deepEqual(config, {
+      assert.deepEqual(config, helpers.normalize({
         'uglify': {'staging/uglify/foo.js': ['app/foo.js'], 'staging/uglify/bar.js': ['app/bar.js'], 'staging/uglify/baz.js': ['app/baz.js']},
         'concat': {'dist/scripts/site.js': ['staging/uglify/foo.js', 'staging/uglify/bar.js', 'staging/uglify/baz.js']}
-      });
+      }));
     });
 
     it('should augment the furnished config', function() {
@@ -109,10 +109,10 @@ describe('ConfigWriter', function () {
       var file = helpers.createFile('foo', 'app', blocks);
       var c = new ConfigWriter( flow, [], {input: 'app', dest: 'destination', staging: '.tmp'} );
       config = c.process(file, config);
-      assert.deepEqual(config, {
+      assert.deepEqual(config, helpers.normalize({
         'concat':{'.tmp/concat/scripts/site.js': ['app/foo.js', 'app/bar.js', 'app/baz.js'], 'foo.js': 'bar.js'},
         'uglify': {'destination/scripts/site.js': ['.tmp/concat/scripts/site.js']}
-      });
+      }));
     });
 
     it('should allow for an empty flow');

--- a/test/test-fileprocessor.js
+++ b/test/test-fileprocessor.js
@@ -132,14 +132,14 @@ describe('FileProcessor', function() {
 	describe('html type', function() {
 		var fp;
 		var filemapping = {
-		    'foo.js': '1234.foo.js',
-		    '/foo.js': '/1234.foo.js',
-		    'app/bar.css': '5678.bar.css',
-		    'app/baz.css': '/8910.baz.css',
-		    'app/image.png': '1234.image.png',
-		    'tmp/bar.css': '1234.bar.css',
-		    'app/foo.js': '1234.foo.js',
-		    '/styles/main.css': '/styles/1234.main.css'
+		    'foo.js': 'foo.1234.js',
+		    '/foo.js': '/foo.1234.js',
+		    'app/bar.css': 'bar.5678.css',
+		    'app/baz.css': '/baz.8910.css',
+		    'app/image.png': 'image.1234.png',
+		    'tmp/bar.css': 'bar.1234.css',
+		    'app/foo.js': 'foo.1234.js',
+		    '/styles/main.css': '/styles/main.1234.css'
 	    };
 
 		var revvedfinder = helpers.makeFinder(filemapping);
@@ -184,7 +184,7 @@ describe('FileProcessor', function() {
 
       it('should replace file referenced from root', function () {
 	        var replaced = fp.replaceWithRevved('<link rel="stylesheet" href="/styles/main.css">', ['']);
-	        assert.equal(replaced, '<link rel="stylesheet" href="/styles/1234.main.css">');
+	        assert.equal(replaced, '<link rel="stylesheet" href="/styles/main.1234.css">');
 	      });
 
       it('should not replace the root (i.e /)', function () {
@@ -204,8 +204,8 @@ describe('FileProcessor', function() {
 	        var content = '<script src="foo.js" type="text/javascript"></script><link rel="stylesheet" href="/baz.css">';
 	        var replaced = fp.replaceWithRevved(content, ['app', 'tmp']);
 
-	        assert.ok(replaced.match(/<link rel="stylesheet" href="\/8910\.baz\.css">/));
-	        assert.ok(replaced.match(/<script src="1234\.foo\.js" type="text\/javascript"><\/script>/));
+	        assert.ok(replaced.match(/<link rel="stylesheet" href="\/baz\.8910\.css">/));
+	        assert.ok(replaced.match(/<script src="foo\.1234\.js" type="text\/javascript"><\/script>/));
 	      });
     });
 
@@ -233,7 +233,7 @@ describe('FileProcessor', function() {
     it('should replace CSS reference with revved version', function () {
 	      var content = '<link rel="stylesheet" href="bar.css">';
 	      var replaced = fp.replaceWithRevved(content, ['app']);
-	      assert.equal(replaced, '<link rel="stylesheet" href="5678.bar.css">');
+	      assert.equal(replaced, '<link rel="stylesheet" href="bar.5678.css">');
 	    });
 
     it('should replace img reference with revved version', function () {
@@ -273,12 +273,12 @@ describe('FileProcessor', function() {
     describe('absolute path', function() {
 			var content = '.myclass {\nbackground: url("/images/test.png") no-repeat center center;\nbackground: url("/images/misc/test.png") no-repeat center center;\nbackground: url("//images/foo.png") no-repeat center center;}';
 			var filemapping = {
-	      'build/images/test.png': '/images/23012.test.png',
-	      'build/images/foo.png': '//images/23012.foo.png',
-	      'build/images/misc/test.png': '/images/misc/23012.test.png',
-	      'foo/images/test.png': '/images/23012.test.png',
-	      'foo/images/foo.png': '//images/23012.foo.png',
-	      'foo/images/misc/test.png': '/images/misc/23012.test.png'
+	      'build/images/test.png': '/images/test.23012.png',
+	      'build/images/foo.png': '//images/foo.23012.png',
+	      'build/images/misc/test.png': '/images/misc/test.23012.png',
+	      'foo/images/test.png': '/images/test.23012.png',
+	      'foo/images/foo.png': '//images/foo.23012.png',
+	      'foo/images/misc/test.png': '/images/misc/test.23012.png'
 			};
 
 			var revvedfinder = helpers.makeFinder(filemapping);
@@ -290,17 +290,17 @@ describe('FileProcessor', function() {
 	    it('should replace with revved files when found', function(){
 		      var changed = cp.replaceWithRevved(content,['build']);
 
-		      assert.ok(changed.match(/\/images\/23012\.test\.png/));
-		      assert.ok(changed.match(/\/images\/misc\/23012\.test\.png/));
-		      assert.ok(changed.match(/\/\/images\/23012\.foo\.png/));
+		      assert.ok(changed.match(/\/images\/test\.23012\.png/));
+		      assert.ok(changed.match(/\/images\/misc\/test\.23012\.png/));
+		      assert.ok(changed.match(/\/\/images\/foo\.23012\.png/));
 		    });
 
 	    it('should take into account alternate search paths', function(){
 		      var changed = cp.replaceWithRevved(content, ['foo']);
 
-		      assert.ok(changed.match(/\/images\/23012\.test\.png/));
-		      assert.ok(changed.match(/\/images\/misc\/23012\.test\.png/));
-		      assert.ok(changed.match(/\/\/images\/23012\.foo\.png/));
+		      assert.ok(changed.match(/\/images\/test\.23012\.png/));
+		      assert.ok(changed.match(/\/images\/misc\/test\.23012\.png/));
+		      assert.ok(changed.match(/\/\/images\/foo\.23012\.png/));
 
 		    });
 
@@ -309,11 +309,11 @@ describe('FileProcessor', function() {
     describe('relative path', function() {
 			var content = '.myclass {\nbackground: url("images/test.png") no-repeat center center;\nbackground: url("../images/misc/test.png") no-repeat center center;\nbackground: url("images/foo.png") no-repeat center center;}';
 			var filemapping = {
-	      'build/images/test.png': 'images/23012.test.png',
-	      'build/images/foo.png': 'images/23012.foo.png',
-	      'images/misc/test.png': '../images/misc/23012.test.png',
-	      'foo/images/test.png': 'images/23012.test.png',
-	      'foo/images/foo.png': 'images/23012.foo.png',
+	      'build/images/test.png': 'images/test.23012.png',
+	      'build/images/foo.png': 'images/foo.23012.png',
+	      'images/misc/test.png': '../images/misc/test.23012.png',
+	      'foo/images/test.png': 'images/test.23012.png',
+	      'foo/images/foo.png': 'images/foo.23012.png',
 			};
 
 			var revvedfinder = helpers.makeFinder(filemapping);
@@ -325,17 +325,17 @@ describe('FileProcessor', function() {
 	    it('should replace with revved files when found', function(){
 		      var changed = cp.replaceWithRevved(content, ['build']);
 
-		      assert.ok(changed.match(/\"images\/23012\.test\.png/));
-		      assert.ok(changed.match(/\"\.\.\/images\/misc\/23012\.test\.png/));
-		      assert.ok(changed.match(/\"images\/23012\.foo\.png/));
+		      assert.ok(changed.match(/\"images\/test\.23012\.png/));
+		      assert.ok(changed.match(/\"\.\.\/images\/misc\/test\.23012\.png/));
+		      assert.ok(changed.match(/\"images\/foo\.23012\.png/));
 		    });
 
 	    it('should take into account alternate search paths', function(){
 		      var changed = cp.replaceWithRevved(content, ['foo']);
 
-		      assert.ok(changed.match(/\"images\/23012\.test\.png/));
-		      assert.ok(changed.match(/\"\.\.\/images\/misc\/23012\.test\.png/));
-		      assert.ok(changed.match(/\"images\/23012\.foo\.png/));
+		      assert.ok(changed.match(/\"images\/test\.23012\.png/));
+		      assert.ok(changed.match(/\"\.\.\/images\/misc\/test\.23012\.png/));
+		      assert.ok(changed.match(/\"images\/foo\.23012\.png/));
 
 		    });
     });

--- a/test/test-revvedfinder.js
+++ b/test/test-revvedfinder.js
@@ -1,6 +1,7 @@
 'use strict';
 var assert = require('assert');
 var RevvedFinder = require('../lib/revvedfinder');
+var helpers = require('./helpers');
 var expandfn = function () {
   return [];
 };
@@ -30,10 +31,10 @@ describe('RevvedFinder', function () {
 
       it('should return revved version of the given file', function () {
         var rf = new RevvedFinder(function () {
-          return ['./2345.image.png'];
+          return ['./image.2345.png'];
         });
         var rfile = rf.find('image.png', '.');
-        assert.equal('2345.image.png', rfile );
+        assert.equal('image.2345.png', rfile );
       });
 
       // it('should pay attention to the full given path', function () {
@@ -52,7 +53,7 @@ describe('RevvedFinder', function () {
 
       it('should regexp quote the looked-after file', function (done) {
         var rf = new RevvedFinder(function (pattern) {
-          assert.equal('*.image.png', pattern);
+          assert.equal('image.*.png', pattern);
           done();
           return [];
         });
@@ -61,10 +62,10 @@ describe('RevvedFinder', function () {
 
       it('should return revved version if it ends hex in characters', function () {
         var rf = new RevvedFinder(function () {
-          return ['11916fba.image.png'];
+          return ['image.11916fba.png'];
         });
         var rfile = rf.find('image.png', '.');
-        assert.equal(rfile, '11916fba.image.png');
+        assert.equal(rfile, 'image.11916fba.png');
 
       });
 
@@ -93,32 +94,32 @@ describe('RevvedFinder', function () {
       describe('absolute paths', function() {
         it('should return the revved file', function() {
           var rf = new RevvedFinder(function () {
-            return ['bar/baz/1234.foo.png'];
+            return ['bar/baz/foo.1234.png'];
           });
           var rfile = rf.find('/foo.png', 'bar/baz');
-          assert.equal(rfile, '/1234.foo.png');
+          assert.equal(rfile, '/foo.1234.png');
         });
 
         it('should look for the file in furnished search path', function() {
           var rf = new RevvedFinder(function () {
-            return ['temp/bar/2345.image.png'];
+            return ['temp/bar/image.2345.png'];
           });
           var rfile = rf.find('/bar/image.png', ['temp']);
-          assert.equal('/bar/2345.image.png', rfile);
+          assert.equal('/bar/image.2345.png', rfile);
         });
 
         it('should allow for several seach paths', function() {
           var rf = new RevvedFinder(function () {
-            return ['foo/bar/2345.image.png'];
+            return ['foo/bar/image.2345.png'];
           });
           var rfile = rf.find('/bar/image.png', ['temp', 'foo']);
-          assert.equal('/bar/2345.image.png', rfile);
+          assert.equal('/bar/image.2345.png', rfile);
         });
       });
 
       it('should only look under the furnished directory', function () {
         var rf = new RevvedFinder(function (pattern) {
-          assert.equal(pattern, 'bar/*.fred.html');
+          assert.equal(pattern, helpers.normalize('bar/fred.*.html'));
           return ['fred.html'];
         });
         var rfile = rf.find('fred.html', 'bar');
@@ -164,34 +165,34 @@ describe('RevvedFinder', function () {
 
       it('should return matching file as well as base directory', function() {
         var rf = new RevvedFinder(function () {
-          return ['temp/./2323.fred.html'];
+          return ['temp/./fred.2323.html'];
         });
         var rfile = rf.find('fred.html', ['temp', 'dist']);
-        assert.equal(rfile, '2323.fred.html');
+        assert.equal(rfile, 'fred.2323.html');
 
         rf = new RevvedFinder(function () {
-          return ['dist/bar/../2323.fred.html'];
+          return ['dist/bar/../fred.2323.html'];
         });
         rfile = rf.find('../fred.html', ['temp/foo', 'dist/bar']);
-        assert.equal(rfile, '../2323.fred.html');
+        assert.equal(rfile, '../fred.2323.html');
 
         rf = new RevvedFinder(function () {
-          return ['dist/bar/1234.test.png', 'dist/bar/images/1234.test.png'];
+          return ['dist/bar/test.1234.png', 'dist/bar/images/test.1234.png'];
         });
         rfile = rf.find('images/test.png', ['temp/foo', 'dist/bar']);
-        assert.equal(rfile, 'images/1234.test.png');
+        assert.equal(rfile, 'images/test.1234.png');
 
         rf = new RevvedFinder(function () {
-          return ['dist/bar/../1234.test.png', 'dist/bar/../images/1234.test.png'];
+          return ['dist/bar/../test.1234.png', 'dist/bar/../images/test.1234.png'];
         });
         rfile = rf.find('../images/test.png', ['temp/foo', 'dist/bar']);
-        assert.equal(rfile, '../images/1234.test.png');
+        assert.equal(rfile, '../images/test.1234.png');
 
         rf = new RevvedFinder(function () {
-          return ['dist/bar/images/1234.test.png', 'dist/bar/images/misc/1234.test.png'];
+          return ['dist/bar/images/test.1234.png', 'dist/bar/images/misc/test.1234.png'];
         });
         rfile = rf.find('images/misc/test.png', ['temp/foo', 'dist/bar']);
-        assert.equal(rfile, 'images/misc/1234.test.png');
+        assert.equal(rfile, 'images/misc/test.1234.png');
       });
 
       it('should return the path under which the file has been found');
@@ -200,23 +201,23 @@ describe('RevvedFinder', function () {
     describe('mapping', function() {
       describe('relative paths', function() {
         it('should return the corresponding file', function() {
-          var rf = new RevvedFinder({'dist/images/misc/test.png': 'dist/images/misc/34546.test.png'});
+          var rf = new RevvedFinder(helpers.normalize({'dist/images/misc/test.png': 'dist/images/misc/test.34546.png'}));
           var file = rf.find('images/misc/test.png', ['temp', 'dist']);
-          assert.equal(file, 'images/misc/34546.test.png');
+          assert.equal(file, 'images/misc/test.34546.png');
         });
 
         it('should handle correctly complicated relative paths', function() {
-          var rf = new RevvedFinder({'images/misc/test.png': 'images/misc/34546.test.png'});
+          var rf = new RevvedFinder(helpers.normalize({'images/misc/test.png': 'images/misc/test.34546.png'}));
           var file = rf.find('../../images/misc/test.png', ['temp/foo', 'dist/bar']);
-          assert.equal(file, '../../images/misc/34546.test.png');
+          assert.equal(file, '../../images/misc/test.34546.png');
         });
 
       });
       describe('absolute paths', function() {
         it('should return the corresponding file', function() {
-          var rf = new RevvedFinder({'dist/images/misc/test.png': 'dist/images/misc/34546.test.png'});
+          var rf = new RevvedFinder(helpers.normalize({'dist/images/misc/test.png': 'dist/images/misc/test.34546.png'}));
           var file = rf.find('/images/misc/test.png', ['temp', 'dist']);
-          assert.equal(file, '/images/misc/34546.test.png');
+          assert.equal(file, '/images/misc/test.34546.png');
         });
       });
     });

--- a/test/test-usemin.js
+++ b/test/test-usemin.js
@@ -37,9 +37,9 @@ describe('usemin', function () {
         grunt.file.mkdir('build');
         grunt.file.mkdir('build/images');
         grunt.file.mkdir('build/images/misc');
-        grunt.file.write('build/images/23012.test.png', 'foo');
-        grunt.file.write('build/images/23012.bar.png', 'foo');
-        grunt.file.write('build/images/misc/2a436.test.png', 'foo');
+        grunt.file.write('build/images/test.23012.png', 'foo');
+        grunt.file.write('build/images/bar.23012.png', 'foo');
+        grunt.file.write('build/images/misc/test.2a436.png', 'foo');
         grunt.file.copy(path.join(__dirname, 'fixtures/htmlprocessor_absolute.html'), 'build/index.html');
 
         grunt.log.muted = true;
@@ -51,9 +51,9 @@ describe('usemin', function () {
 
         var changed = grunt.file.read('build/index.html');
 
-        assert.ok(changed.match(/<img src="\/images\/23012\.test\.png">/));
-        assert.ok(changed.match(/<img src="\/\/images\/23012\.bar\.png">/));
-        assert.ok(changed.match(/<img src="\/images\/misc\/2a436\.test\.png">/));
+        assert.ok(changed.match(/<img src="\/images\/test\.23012\.png">/));
+        assert.ok(changed.match(/<img src="\/\/images\/bar\.23012\.png">/));
+        assert.ok(changed.match(/<img src="\/images\/misc\/test\.2a436\.png">/));
 
       });
 
@@ -62,9 +62,9 @@ describe('usemin', function () {
         grunt.file.mkdir('foo');
         grunt.file.mkdir('foo/images');
         grunt.file.mkdir('foo/images/foo');
-        grunt.file.write('foo/images/23012.test.png', 'foo');
-        grunt.file.write('foo/images/23012.bar.png', 'foo');
-        grunt.file.write('foo/images/misc/2a436.test.png', 'foo');
+        grunt.file.write('foo/images/test.23012.png', 'foo');
+        grunt.file.write('foo/images/bar.23012.png', 'foo');
+        grunt.file.write('foo/images/misc/test.2a436.png', 'foo');
         grunt.file.copy(path.join(__dirname, 'fixtures/htmlprocessor_absolute.html'), 'build/index.html');
 
         grunt.log.muted = true;
@@ -75,9 +75,9 @@ describe('usemin', function () {
 
         var changed = grunt.file.read('build/index.html');
 
-        assert.ok(changed.match(/<img src="\/images\/23012\.test\.png">/));
-        assert.ok(changed.match(/<img src="\/\/images\/23012\.bar\.png">/));
-        assert.ok(changed.match(/<img src="\/images\/misc\/2a436\.test\.png">/));
+        assert.ok(changed.match(/<img src="\/images\/test\.23012\.png">/));
+        assert.ok(changed.match(/<img src="\/\/images\/bar\.23012\.png">/));
+        assert.ok(changed.match(/<img src="\/images\/misc\/test\.2a436\.png">/));
 
       });
 
@@ -86,13 +86,13 @@ describe('usemin', function () {
         grunt.file.mkdir('foo');
         grunt.file.mkdir('foo/images');
         grunt.file.mkdir('foo/images/misc');
-        grunt.file.write('foo/images/23012.test.png', 'foo');
-        grunt.file.write('foo/images/23012.bar.png', 'foo');
-        grunt.file.write('foo/images/misc/2a436.test.png', 'foo');
+        grunt.file.write('foo/images/test.23012.png', 'foo');
+        grunt.file.write('foo/images/bar.23012.png', 'foo');
+        grunt.file.write('foo/images/misc/test.2a436.png', 'foo');
         grunt.file.mkdir('bar');
         grunt.file.mkdir('bar/scripts');
-        grunt.file.write('bar/scripts/12345.plugins.js', 'bar');
-        grunt.file.write('bar/scripts/6789.amd-app.js', 'bar');
+        grunt.file.write('bar/scripts/plugins.12345.js', 'bar');
+        grunt.file.write('bar/scripts/amd-app.6789.js', 'bar');
         grunt.file.copy(path.join(__dirname, 'fixtures/htmlprocessor_absolute.html'), 'build/index.html');
 
         grunt.log.muted = true;
@@ -103,11 +103,11 @@ describe('usemin', function () {
 
         var changed = grunt.file.read('build/index.html');
 
-        assert.ok(changed.match(/<img src="\/images\/23012\.test\.png">/));
-        assert.ok(changed.match(/<img src="\/\/images\/23012\.bar\.png">/));
-        assert.ok(changed.match(/<img src="\/images\/misc\/2a436\.test\.png">/));
-        assert.ok(changed.match(/<script src="\/scripts\/12345\.plugins\.js">/));
-        assert.ok(changed.match(/<script data-main="\/scripts\/6789\.amd-app"/));
+        assert.ok(changed.match(/<img src="\/images\/test\.23012\.png">/));
+        assert.ok(changed.match(/<img src="\/\/images\/bar\.23012\.png">/));
+        assert.ok(changed.match(/<img src="\/images\/misc\/test\.2a436\.png">/));
+        assert.ok(changed.match(/<script src="\/scripts\/plugins\.12345\.js">/));
+        assert.ok(changed.match(/<script data-main="\/scripts\/amd-app\.6789"/));
 
       });
 
@@ -121,9 +121,9 @@ describe('usemin', function () {
         grunt.file.mkdir('build/images');
         grunt.file.mkdir('build/foo');
         grunt.file.mkdir('build/images/misc');
-        grunt.file.write('build/images/23012.test.png', 'foo');
-        grunt.file.write('build/images/23012.bar.png', 'foo');
-        grunt.file.write('build/images/misc/2a436.test.png', 'foo');
+        grunt.file.write('build/images/test.23012.png', 'foo');
+        grunt.file.write('build/images/bar.23012.png', 'foo');
+        grunt.file.write('build/images/misc/test.2a436.png', 'foo');
         grunt.file.copy(path.join(__dirname, 'fixtures/htmlprocessor_relative.html'), 'build/foo/index.html');
 
         grunt.log.muted = true;
@@ -134,9 +134,9 @@ describe('usemin', function () {
 
         var changed = grunt.file.read('build/foo/index.html');
 
-        assert.ok(changed.match(/<img src="\.\.\/images\/23012\.test\.png">/));
+        assert.ok(changed.match(/<img src="\.\.\/images\/test\.23012\.png">/));
         assert.ok(changed.match(/<link rel=\"stylesheet\" href=\"styles\/main\.min\.css\">/));
-        assert.ok(changed.match(/<img src=\"\.\.\/images\/misc\/2a436\.test\.png\">/));
+        assert.ok(changed.match(/<img src=\"\.\.\/images\/misc\/test\.2a436\.png\">/));
 
       });
 
@@ -146,9 +146,9 @@ describe('usemin', function () {
         grunt.file.mkdir('foo/bar');
         grunt.file.mkdir('foo/images');
         grunt.file.mkdir('foo/images/foo');
-        grunt.file.write('foo/images/23012.test.png', 'foo');
-        grunt.file.write('foo/images/23012.bar.png', 'foo');
-        grunt.file.write('foo/images/misc/2a436.test.png', 'foo');
+        grunt.file.write('foo/images/test.23012.png', 'foo');
+        grunt.file.write('foo/images/bar.23012.png', 'foo');
+        grunt.file.write('foo/images/misc/test.2a436.png', 'foo');
         grunt.file.copy(path.join(__dirname, 'fixtures/htmlprocessor_relative.html'), 'build/index.html');
 
         grunt.log.muted = true;
@@ -159,8 +159,8 @@ describe('usemin', function () {
 
         var changed = grunt.file.read('build/index.html');
 
-        assert.ok(changed.match(/<img src="\.\.\/images\/23012\.test\.png">/));
-        assert.ok(changed.match(/<img src="\.\.\/images\/misc\/2a436\.test\.png">/));
+        assert.ok(changed.match(/<img src="\.\.\/images\/test\.23012\.png">/));
+        assert.ok(changed.match(/<img src="\.\.\/images\/misc\/test\.2a436\.png">/));
       });
 
     it('should allow for several asset dirs', function () {
@@ -168,13 +168,13 @@ describe('usemin', function () {
         grunt.file.mkdir('foo/bar');
         grunt.file.mkdir('foo/images');
         grunt.file.mkdir('foo/images/misc');
-        grunt.file.write('foo/images/23012.test.png', 'foo');
-        grunt.file.write('foo/images/23012.bar.png', 'foo');
-        grunt.file.write('foo/images/misc/2a436.test.png', 'foo');
+        grunt.file.write('foo/images/test.23012.png', 'foo');
+        grunt.file.write('foo/images/bar.23012.png', 'foo');
+        grunt.file.write('foo/images/misc/test.2a436.png', 'foo');
         grunt.file.mkdir('bar');
         grunt.file.mkdir('bar/scripts');
-        grunt.file.write('bar/scripts/12345.plugins.js', 'bar');
-        grunt.file.write('bar/scripts/6789.amd-app.js', 'bar');
+        grunt.file.write('bar/scripts/plugins.12345.js', 'bar');
+        grunt.file.write('bar/scripts/amd-app.6789.js', 'bar');
         grunt.file.copy(path.join(__dirname, 'fixtures/htmlprocessor_relative.html'), 'build/index.html');
 
         grunt.log.muted = true;
@@ -185,10 +185,10 @@ describe('usemin', function () {
 
         var changed = grunt.file.read('build/index.html');
 
-        assert.ok(changed.match(/<img src="\.\.\/images\/23012\.test\.png">/));
-        assert.ok(changed.match(/<img src="\.\.\/images\/misc\/2a436\.test\.png">/));
-        assert.ok(changed.match(/<script src="scripts\/12345\.plugins\.js">/));
-        assert.ok(changed.match(/<script data-main="scripts\/6789\.amd-app"/));
+        assert.ok(changed.match(/<img src="\.\.\/images\/test\.23012\.png">/));
+        assert.ok(changed.match(/<img src="\.\.\/images\/misc\/test\.2a436\.png">/));
+        assert.ok(changed.match(/<script src="scripts\/plugins\.12345\.js">/));
+        assert.ok(changed.match(/<script data-main="scripts\/amd-app\.6789"/));
 
       });
 
@@ -199,8 +199,8 @@ describe('usemin', function () {
   it('should work on CSS files', function () {
     grunt.file.mkdir('images');
     grunt.file.mkdir('images/misc');
-    grunt.file.write('images/23012.test.png', 'foo');
-    grunt.file.write('images/misc/2a436.test.png', 'foo');
+    grunt.file.write('images/test.23012.png', 'foo');
+    grunt.file.write('images/misc/test.2a436.png', 'foo');
     grunt.log.muted = true;
     grunt.config.init();
     grunt.config('usemin', {css: 'style.css'});
@@ -211,10 +211,10 @@ describe('usemin', function () {
     var changed = grunt.file.read('style.css');
 
     // Check replace has performed its duty
-    assert.ok(changed.match(/url\(\"images\/23012\.test\.png\"/));
-    assert.ok(changed.match(/url\(\"images\/misc\/2a436\.test\.png\"/));
-    assert.ok(changed.match(/url\(\"\/\/images\/23012\.test\.png\"/));
-    assert.ok(changed.match(/url\(\"\/images\/23012\.test\.png\"/));
+    assert.ok(changed.match(/url\(\"images\/test\.23012\.png\"/));
+    assert.ok(changed.match(/url\(\"images\/misc\/test\.2a436\.png\"/));
+    assert.ok(changed.match(/url\(\"\/\/images\/test\.23012\.png\"/));
+    assert.ok(changed.match(/url\(\"\/images\/test\.23012\.png\"/));
   });
 
   it('should not replace reference to file not revved', function () {
@@ -235,7 +235,7 @@ describe('usemin', function () {
 
   it('should consider that data-main point to a JS file', function () {
     grunt.file.mkdir('scripts');
-    grunt.file.write('scripts/23012.main.js', 'foo');
+    grunt.file.write('scripts/main.23012.js', 'foo');
     grunt.log.muted = true;
     grunt.config.init();
     grunt.config('usemin', {html: 'index.html'});
@@ -246,13 +246,13 @@ describe('usemin', function () {
     var changed = grunt.file.read('index.html');
 
     // Check replace has performed its duty
-    assert.ok(changed.match(/data-main="scripts\/23012\.main"/));
+    assert.ok(changed.match(/data-main="scripts\/main\.23012"/));
   });
 
 
   it('should use the furnished require.js source when replacing', function () {
     grunt.file.mkdir('scripts');
-    grunt.file.write('scripts/23012.amd-app.js', 'foo');
+    grunt.file.write('scripts/amd-app.23012.js', 'foo');
     grunt.log.muted = true;
     grunt.config.init();
     grunt.config('usemin', {html: 'index.html'});
@@ -262,13 +262,13 @@ describe('usemin', function () {
 
     var changed = grunt.file.read('index.html');
     // Check replace has performed its duty
-    assert.ok(changed.match(/data-main="scripts\/23012\.amd-app"\s+src="foo\/require\.js"/));
+    assert.ok(changed.match(/data-main="scripts\/amd-app\.23012"\s+src="foo\/require\.js"/));
 
   });
 
   it('should allow for additional replacement patterns', function () {
     grunt.file.mkdir('images');
-    grunt.file.write('images/2132.image.png', 'foo');
+    grunt.file.write('images/image.2132.png', 'foo');
     grunt.log.muted = true;
     grunt.config.init();
     grunt.config('usemin', {
@@ -289,7 +289,7 @@ describe('usemin', function () {
     var changed = grunt.file.read('misc.js');
 
     // Check replace has performed its duty
-    assert.ok(changed.match(/referenceToImage = '2132\.image\.png'/));
+    assert.ok(changed.match(/referenceToImage = 'image\.2132\.png'/));
   });
 
 
@@ -307,22 +307,22 @@ describe('useminPrepare', function () {
     var concat = grunt.config('concat');
 
     assert.ok(concat);
-    assert.ok(concat['.tmp/concat/scripts/plugins.js']);
-    assert.equal(concat['.tmp/concat/scripts/plugins.js'].length, 13);
-    assert.ok(concat['.tmp/concat/styles/main.min.css']);
-    assert.equal(concat['.tmp/concat/styles/main.min.css'].length, 1);
+    assert.ok(concat[path.normalize('.tmp/concat/scripts/plugins.js')]);
+    assert.equal(concat[path.normalize('.tmp/concat/scripts/plugins.js')].length, 13);
+    assert.ok(concat[path.normalize('.tmp/concat/styles/main.min.css')]);
+    assert.equal(concat[path.normalize('.tmp/concat/styles/main.min.css')].length, 1);
 
     var requirejs = grunt.config('requirejs');
     assert.ok(requirejs.default.options.baseUrl);
     assert.equal(requirejs.default.options.baseUrl, 'scripts');
     assert.ok(requirejs.default.options.name);
     assert.equal(requirejs.default.options.name, 'main');
-    assert.equal(requirejs.default.options.out, 'dist/scripts/amd-app.js');
+    assert.equal(requirejs.default.options.out, path.normalize('dist/scripts/amd-app.js'));
 
 
     var uglify = grunt.config('uglify');
-    assert.equal(uglify['dist/scripts/amd-app.js'], '.tmp/concat/scripts/amd-app.js');
-    assert.equal(uglify['dist/scripts/plugins.js'], '.tmp/concat/scripts/plugins.js');
+    assert.equal(uglify[path.normalize('dist/scripts/amd-app.js')], path.normalize('.tmp/concat/scripts/amd-app.js'));
+    assert.equal(uglify[path.normalize('dist/scripts/plugins.js')], path.normalize('.tmp/concat/scripts/plugins.js'));
   });
 
   it('should use alternate search dir if asked to', function () {
@@ -335,13 +335,13 @@ describe('useminPrepare', function () {
 
     var concat = grunt.config('concat');
     assert.ok(concat);
-    assert.ok(concat['.tmp/concat/scripts/foo.js']);
-    assert.equal(concat['.tmp/concat/scripts/foo.js'].length, 2);
-    assert.equal(concat['.tmp/concat/scripts/foo.js'][0], 'build/scripts/bar.js');
-    assert.equal(concat['.tmp/concat/scripts/foo.js'][1], 'build/scripts/baz.js');
+    assert.ok(concat[path.normalize('.tmp/concat/scripts/foo.js')]);
+    assert.equal(concat[path.normalize('.tmp/concat/scripts/foo.js')].length, 2);
+    assert.equal(concat[path.normalize('.tmp/concat/scripts/foo.js')][0], path.normalize('build/scripts/bar.js'));
+    assert.equal(concat[path.normalize('.tmp/concat/scripts/foo.js')][1], path.normalize('build/scripts/baz.js'));
 
     var uglify = grunt.config('uglify');
-    assert.deepEqual(uglify['dist/scripts/foo.js'], ['.tmp/concat/scripts/foo.js']);
+    assert.deepEqual(uglify[path.normalize('dist/scripts/foo.js')], [path.normalize('.tmp/concat/scripts/foo.js')]);
   });
 
   it('should update all requirejs multitask configs setting name and output', function () {
@@ -368,13 +368,13 @@ describe('useminPrepare', function () {
     assert.equal(requirejs.task1.options.name, 'main');
     assert.equal(requirejs.task2.options.name, 'main');
 
-    assert.equal(requirejs.task1.options.out, 'dist/scripts/amd-app.js');
-    assert.equal(requirejs.task2.options.out, 'dist/scripts/amd-app.js');
+    assert.equal(requirejs.task1.options.out, path.normalize('dist/scripts/amd-app.js'));
+    assert.equal(requirejs.task2.options.out, path.normalize('dist/scripts/amd-app.js'));
 
     assert.equal(requirejs.task1.options.baseUrl, 'scripts');
     assert.equal(requirejs.task2.options.baseUrl, 'base');
 
-    assert.equal(requirejs.task1.options.mainConfigFile, 'scripts/main.js');
+    assert.equal(requirejs.task1.options.mainConfigFile, path.normalize('scripts/main.js'));
     // assert.equal(requirejs.task2.options.mainConfigFile, 'base');
   });
 
@@ -397,11 +397,11 @@ describe('useminPrepare', function () {
 
     assert.equal(requirejs.task1.options.name, 'main');
 
-    assert.equal(requirejs.task1.options.out, 'dist/scripts/amd-app.js');
+    assert.equal(requirejs.task1.options.out, path.normalize('dist/scripts/amd-app.js'));
 
-    assert.equal(requirejs.task1.options.baseUrl, 'app/scripts');
+    assert.equal(requirejs.task1.options.baseUrl, path.normalize('app/scripts'));
 
-    assert.equal(requirejs.task1.options.mainConfigFile, 'app/scripts/main.js');
+    assert.equal(requirejs.task1.options.mainConfigFile, path.normalize('app/scripts/main.js'));
   });
 
   it('should create a requirejs multitask config setting with name and output if non settings exists', function () {
@@ -417,7 +417,7 @@ describe('useminPrepare', function () {
 
     assert.ok(requirejs.default.options.name);
     assert.equal(requirejs.default.options.name, 'main');
-    assert.equal(requirejs.default.options.out, 'dist/scripts/amd-app.js');
+    assert.equal(requirejs.default.options.out, path.normalize('dist/scripts/amd-app.js'));
     assert.equal(requirejs.default.options.baseUrl, 'scripts');
   });
 
@@ -432,20 +432,20 @@ describe('useminPrepare', function () {
 
     var concat = grunt.config('concat');
     assert.ok(concat);
-    assert.ok(concat['.tmp/concat/scripts/foo.js']);
-    assert.equal(concat['.tmp/concat/scripts/foo.js'].length, 2);
+    assert.ok(concat[path.normalize('.tmp/concat/scripts/foo.js')]);
+    assert.equal(concat[path.normalize('.tmp/concat/scripts/foo.js')].length, 2);
 
     var requirejs = grunt.config('requirejs');
 
     assert.ok(requirejs.default.options.baseUrl);
-    assert.equal(requirejs.default.options.baseUrl, 'build/scripts');
+    assert.equal(requirejs.default.options.baseUrl, path.normalize('build/scripts'));
     assert.ok(requirejs.default.options.name);
     assert.equal(requirejs.default.options.name, 'main');
-    assert.equal(requirejs.default.options.out, 'dist/scripts/amd-app.js');
+    assert.equal(requirejs.default.options.out, path.normalize('dist/scripts/amd-app.js'));
 
     var uglify = grunt.config('uglify');
-    assert.deepEqual(uglify['dist/scripts/amd-app.js'], ['.tmp/concat/scripts/amd-app.js']);
-    assert.deepEqual(uglify['dist/scripts/foo.js'], ['.tmp/concat/scripts/foo.js']);
+    assert.deepEqual(uglify[path.normalize('dist/scripts/amd-app.js')], [path.normalize('.tmp/concat/scripts/amd-app.js')]);
+    assert.deepEqual(uglify[path.normalize('dist/scripts/foo.js')], [path.normalize('.tmp/concat/scripts/foo.js')]);
   });
 
   it('should take dest option into consideration', function () {
@@ -458,8 +458,8 @@ describe('useminPrepare', function () {
 
     var uglify = grunt.config('uglify');
 
-    assert.equal(uglify['foo/scripts/amd-app.js'], '.tmp/concat/scripts/amd-app.js');
-    assert.equal(uglify['foo/scripts/plugins.js'], '.tmp/concat/scripts/plugins.js');
+    assert.equal(uglify[path.normalize('foo/scripts/amd-app.js')], path.normalize('.tmp/concat/scripts/amd-app.js'));
+    assert.equal(uglify[path.normalize('foo/scripts/plugins.js')], path.normalize('.tmp/concat/scripts/plugins.js'));
 
   });
 
@@ -487,7 +487,7 @@ describe('useminPrepare', function () {
     assert.equal(requirejs, null);
     assert.ok(uglify);
 
-    assert.equal(uglify['dist/styles/main.min.css'], 'styles/main.css');
+    assert.equal(uglify[path.normalize('dist/styles/main.min.css')], path.normalize('styles/main.css'));
 
   });
 
@@ -517,7 +517,7 @@ describe('useminPrepare', function () {
     assert.equal(requirejs, null);
     assert.ok(uglify);
 
-    assert.equal(uglify['dist/styles/main.min.css'], 'styles/main.css');
+    assert.equal(uglify[path.normalize('dist/styles/main.min.css')], path.normalize('styles/main.css'));
 
   });
 
@@ -551,9 +551,9 @@ describe('useminPrepare', function () {
     var copyCfg = grunt.config('copy');
 
     assert.ok(copyCfg);
-    assert.ok(copyCfg['dist/styles/main.min.css']);
-    assert.ok(copyCfg['dist/scripts/plugins.js']);
-    assert.ok(copyCfg['dist/scripts/amd-app.js']);
+    assert.ok(copyCfg[path.normalize('dist/styles/main.min.css')]);
+    assert.ok(copyCfg[path.normalize('dist/scripts/plugins.js')]);
+    assert.ok(copyCfg[path.normalize('dist/scripts/amd-app.js')]);
 
   });
 });


### PR DESCRIPTION
This is the usemin piece to support grunt-rev's change to suffix/postfix naming described in cbas/grunt-rev#2.  The corresponding grunt-rev PR can be found at cbas/grunt-rev#8.

The necessary changes were larger than I expected, partially due to a desire to get the tests to pass on Windows as well as Mac.  If you'd like to reduce the changes, let me know and I'll  take out the Windows-specific changes.  If it's preferable to wait until v2.0 is merged into master, I can wait for that and then rebase this PR onto master.

I've signed the CLA.
