### PR TITLE
Take care of multiple <script tags on the same line

### DIFF
--- a/lib/htmlprocessor.js
+++ b/lib/htmlprocessor.js
@@ -220,6 +220,8 @@ HTMLProcessor.prototype.replaceWithRevved = function replaceWithRevved(lines) {
     // Replace script sources
     var self = this;
     var content = lines || this.content;
+    // Split lines by <script tags b/c the regexps work on lines
+    content = content.split('<script ').join('\n<script ');
     var regexps = [
       /*jshint regexp:false */
       [/<script.+src=['"]([^"']+)["']/gm,
@@ -269,6 +271,9 @@ HTMLProcessor.prototype.replaceWithRevved = function replaceWithRevved(lines) {
         return res;
       });
     });
+
+    // Unsplit the <script lines
+    content = content.split('\n<script ').join('<script ');
 
     return content;
   };


### PR DESCRIPTION
Hi guys, I don't know if this a goal or a non-goal for you but anyway, I have a situation where I have multiple `<script>` tags on the same line, and then the regular expressions that capture  `<script.+src=['"]([^"']+)["']/gm` doesn't work correctly. Maybe there's an easier way around this (it's my first real project in node) but I didn't find it so I created this patch. This is caused, btw b/c the HTML is generated by grunt-jade. 

The jade processor outputs something like this: (when configured to wrap as a node module)

```
var jade = require('./runtime');
(function (jade) {
    module.exports = function anonymous(locals, attrs, escape, rethrow, merge) {
attrs = attrs || jade.attrs; escape = escape || jade.escape; rethrow = rethrow || jade.rethrow; merge = merge || jade.merge;
var buf = [];
with (locals || {}) {
var interp;
buf.push('<!DOCTYPE html><html>...<body>...<script type="text/javascript" src="/scripts/script1.js"></script><script type="text/javascript" src="/scripts/script2.js"></script>...</body></html>');
}
return buf.join("");
};
})(jade);
```

So this in itself isn't actual HTML, but it's close enough so grunt-usemin is able to process it but the problem is when there are multiple `script` tags on the same line, in which case the capture pattern isn't correct and captures only the second `script2.js`. 

So again, not sure whether this is a goal for you or whether there's a better way to achieve what I need but I wanted to make a PR just to raise the flag and provide a suggested solution.
The solution in itself isn't complete as it takes only care of `script` tags and not of other types of elements that appear in the list of `regexps` but to me that was the only problem and anyway if this is a good direction I can add the rest to this PR.

Thanks!
