### PR TITLE
Use relative paths for destination files

### DIFF
--- a/lib/htmlprocessor.js
+++ b/lib/htmlprocessor.js
@@ -74,7 +74,7 @@ var getBlocks = function (dest, dir, content) {
       }
       last = {
         type: build[1],
-        dest: path.join(dest, build[3]),
+        dest: path.relative(path.resolve(), path.join(dest, build[3])),
         startFromRoot: startFromRoot,
         indent: indent,
         src: [],


### PR DESCRIPTION
Absolute path causes following error on Windows

``` cmd
Running "concat:C:\Users\alexeykuzmin\temp\dist\main.min.js" (concat) task
Verifying property concat.C exists in config...ERROR
>> Unable to process task.
Warning: Required config property "concat.C" missing. Use --force to continue.

Aborted due to warnings.
```
