### PR TITLE
Performance improvement for cssprocessor by caching references

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -2,7 +2,8 @@
   "globals": {
     "before": false,
     "describe": false,
-    "it": false
+    "it": false,
+    "beforeEach": false
   },
   "node": true,
   "browser": true,

--- a/lib/cssprocessor.js
+++ b/lib/cssprocessor.js
@@ -30,11 +30,22 @@ CSSProcessor.prototype.log = function log(msg) {
 //
 CSSProcessor.prototype.process = function process() {
     var self = this;
+
+    var cache = {};
+    var toCache = function (originalPath, replacementPath) {
+        cache[originalPath] = replacementPath;
+      };
+    var fromCache = function (originalPath) {
+        return cache[originalPath];
+      };
+
     // Replace reference to images with the actual name of the optimized image
     this.log('Update the CSS with new img filenames');
     return this.content.replace(/url\(\s*['"]?([^'"\)#?]+)(?:[#?](?:[^'"\)]*))?['"]?\s*\)/gm, function (match, src) {
       // Consider reference from site root
-      var file = self.revvedfinder.find(src, self.filepath);
+      var file = fromCache(src) || self.revvedfinder.find(src, self.filepath);
+      toCache(src, file);
+
       var res = match.replace(src, file);
 
       if (src !== file) {

--- a/test/test-cssprocessor.js
+++ b/test/test-cssprocessor.js
@@ -15,13 +15,22 @@ describe('cssprocessor', function () {
       'images/pic.png': 'images/2123.pic.png',
       '/images/pic.png': '/images/2123.pic.png',
       '../../images/pic.png': '../../images/2123.pic.png',
-      'fonts/awesome-font.svg': 'fonts/2123.awesome-font.svg',
+      'fonts/awesome-font.svg': 'fonts/2123.awesome-font.svg'
     };
     var revvedfinder = {
+      callCount: 0,
       find: function (s) {
+        this.callCount++;
         return mapping[s] || s;
+      },
+      reset: function () {
+        this.callCount = 0;
       }
     };
+
+    beforeEach(function(){
+      revvedfinder.reset();
+    });
 
     it('should update the CSS with new img filenames', function () {
       var content = 'background-image:url(images/pic.png);';
@@ -70,6 +79,14 @@ describe('cssprocessor', function () {
       var cp = new CSSProcessor('', 'build/css', content, revvedfinder);
       var awaited = 'background-image:url(fonts/2123.awesome-font.svg?#iefix);';
       assert.equal(awaited, cp.process());
+    });
+
+    it('should cache replaced references', function () {
+      var content = 'background-image:url(images/pic.png);background-image:url(images/pic.png);';
+      var cp = new CSSProcessor('', '', content, revvedfinder);
+      var awaited = 'background-image:url(images/2123.pic.png);background-image:url(images/2123.pic.png);';
+      assert.equal(awaited, cp.process());
+      assert.equal(1, revvedfinder.callCount);
     });
   });
 });


### PR DESCRIPTION
When running usemin on larger projects with the same image being referenced multiple times, the continuous lookup via the revvedfinder takes up quite a lot of time. If the already found reference is cached instead the processing is a lot faster.

Measurement on a fairly small project (15 images, 50 usages in CSS files):

Buildtime without fix:
Run1: 0m24.691s
Run2: 0m25.317s
Run3: 0m25.200s

Buildtime with cache:
Run1: 0m10.634s
Run2: 0m10.052s
Run3: 0m10.666s

Right now the caching has only been implemented for the cssprocessor, it might be useful to move the caching into or around the RevvedFinder itself.
