### PR TITLE
regenerate package.json to add README

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,5 +40,11 @@
   },
   "licenses": {
     "type": "BSD"
-  }
+  },
+  "gitHead": "a26f298b69220eb22996cf02391710f32c4615c4",
+  "readmeFilename": "README.md",
+  "directories": {
+    "test": "test"
+  },
+  "license": "BSD"
 }


### PR DESCRIPTION
Less `WARN` running `npm install`, and the diff:

```
-  }
+  },
+  "gitHead": "a26f298b69220eb22996cf02391710f32c4615c4",
+  "readmeFilename": "README.md",
+  "directories": {
+    "test": "test"
+  },
+  "license": "BSD"
```
