### PR TITLE
Change base path for all assets

### DIFF
--- a/tasks/usemin.js
+++ b/tasks/usemin.js
@@ -117,6 +117,7 @@ module.exports = function (grunt) {
     var uglifyName = options.uglify || 'uglify';
     var cssminName = options.cssmin || 'cssmin';
     var dest = options.dest;
+    var basePath = options.basePath;
 
     // concat / uglify / cssmin / requirejs config
     var concat = grunt.config('concat') || {};
@@ -137,7 +138,8 @@ module.exports = function (grunt) {
 
     files.forEach(function (file) {
       var revvedfinder = new RevvedFinder(function (p) { return grunt.file.expand({filter: 'isFile'}, p); });
-      var proc = new HTMLProcessor(path.dirname(file.path), dest, file.body, revvedfinder, function (msg) {
+      var srcPath = basePath || path.dirname(file.path);
+      var proc = new HTMLProcessor(srcPath, dest, file.body, revvedfinder, function (msg) {
         grunt.log.writeln(msg);
       });
 

--- a/test/fixtures/custom_basepath.html
+++ b/test/fixtures/custom_basepath.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+    <head>
+        <link rel="stylesheet" href="styles/main.css">
+        <script src="scripts/vendor/modernizr.min.js"></script>
+    </head>
+    <body>
+
+    <!-- build:css styles/main.css -->
+    <script src="styles/first_one.css"></script>
+    <script src="styles/second_one.css"></script>
+    <!-- endbuild -->
+</body>
+</html>

--- a/test/test-usemin.js
+++ b/test/test-usemin.js
@@ -405,6 +405,23 @@ describe('usemin', function () {
       assert.equal(uglify['build/scripts/foo.js'], 'build/scripts/foo.js');
     });
 
+    it('output config for subsequent tasks (requirejs, concat, ..) should be configurable', function () {
+      grunt.log.muted = true;
+      grunt.config.init();
+      grunt.config('useminPrepare', {html: 'build/index.html', options: {basePath: 'different_path', dest: 'out'}});
+      grunt.file.mkdir('build');
+      grunt.file.copy(path.join(__dirname, 'fixtures/custom_basepath.html'), 'build/index.html');
+      grunt.task.run('useminPrepare');
+      grunt.task.start();
+
+      var concat = grunt.config('concat');
+      assert.ok(concat);
+      assert.ok(concat['out/styles/main.css']);
+      assert.equal(concat['out/styles/main.css'].length, 2);
+      assert.equal(concat['out/styles/main.css'][0], 'different_path/styles/first_one.css');
+      assert.equal(concat['out/styles/main.css'][1], 'different_path/styles/second_one.css');
+    });
+
     it('should take dest option into consideration', function () {
       grunt.log.muted = true;
       grunt.config.init();


### PR DESCRIPTION
In my project, all my templates live in app/views folder, whereas all the assets live in app/public, similar to Rails structure. When grunt-usemin is building concat paths, it uses the view's/template's basedir, and for my project, this is not true.

For this reason, I added a new option to useminPrepare in order to set the lookup for all the assets. I also added a new unit test to verify this behavior (and specially, mimic my own project's usage).

Thanks!
