### PR TITLE
Provide option to force src change in requirejs tag

### DIFF
--- a/lib/htmlprocessor.js
+++ b/lib/htmlprocessor.js
@@ -180,7 +180,7 @@ HTMLProcessor.prototype.replaceWith = function replaceWith(block) {
   if (block.type === 'css') {
     var media = block.media ? ' media="' + block.media + '"' : '';
     result = block.indent + '<link rel="stylesheet" href="' + dest + '"' + media + '>';
-  } else if (block.requirejs !== undefined) {
+  } else if (block.requirejs !== undefined && block.type !== 'rawjs') {
     var dataMain = path.relative(this.relativeSrc, block.requirejs.dest);
     dataMain = dataMain.replace(backslash, '/');
     var requireSrc = path.relative(this.relativeSrc, block.requirejs.srcDest);
@@ -190,7 +190,7 @@ HTMLProcessor.prototype.replaceWith = function replaceWith(block) {
       requireSrc = '/' + requireSrc;
     }
     result = block.indent + '<script data-main="' + dataMain + '" src="' + requireSrc + '"><\/script>';
-  } else if (block.type === 'js') {
+  } else if (block.type === 'js' || block.type === 'rawjs') {
     result = block.indent + '<script src="' + dest + '"><\/script>';
   } else {
     result = '';


### PR DESCRIPTION
Not sure whether this is the most semantic way, but I think there should be an option to ignore RequireJS format and replace src with the one provided in usemin comment block.

You can find here an example of usecase: https://github.com/sergeylukin/emmet.docpad/commit/9df7443b248c2c2716e1045214217bde8c3f551e

Hopefully this makes sense
