### PR TITLE
Usemin should handle <script defer>

### DIFF
--- a/lib/htmlprocessor.js
+++ b/lib/htmlprocessor.js
@@ -123,6 +123,16 @@ var getBlocks = function (dest, dir, content) {
         if (media) {
           last.media = media[1];
         }
+
+        // preserve defer attribute
+        var defer = /defer/.test(l);
+        if (defer && last.defer === false || last.defer && !defer) {
+          throw 'Error: You are not suppose to mix deferred and non-deferred scripts in one block.';
+        } else if (defer) {
+          last.defer = true;
+        } else {
+          last.defer = false;
+        }
       }
       last.raw.push(l);
     }
@@ -190,6 +200,8 @@ HTMLProcessor.prototype.replaceWith = function replaceWith(block) {
       requireSrc = '/' + requireSrc;
     }
     result = block.indent + '<script data-main="' + dataMain + '" src="' + requireSrc + '"><\/script>';
+  } else if (block.defer) {
+    result = block.indent + '<script defer src="' + dest + '"><\/script>';
   } else if (block.type === 'js') {
     result = block.indent + '<script src="' + dest + '"><\/script>';
   } else {

--- a/test/test-htmlprocessor.js
+++ b/test/test-htmlprocessor.js
@@ -99,6 +99,44 @@ describe('htmlprocessor', function () {
     assert.equal('main', hp.blocks[0].requirejs.name);
   });
 
+  it('should detect the defer attribute', function () {
+    var htmlcontent = '<!-- build:js foo.js -->\n' +
+    '<script defer src="bar.js"></script>\n' +
+    '<!-- endbuild -->';
+    var hp = new HTMLProcessor('', '', htmlcontent, 3);
+    assert.equal(1, hp.blocks.length);
+    assert.ok(hp.blocks[0].defer);
+    assert.equal(true, hp.blocks[0].defer);
+  });
+
+  it('should throw error if non-deferred script follows a deferred one in one block', function () {
+    var htmlcontent = '<!-- build:js foo.js -->\n' +
+    '<script defer src="bar.js"></script>\n' +
+    '<script src="baz.js"></script>\n' +
+    '<!-- endbuild -->';
+    try {
+      new HTMLProcessor('', '', htmlcontent, 3);
+    } catch (e) {
+      assert.ok(true);
+      return;
+    }
+    assert.ok(false);
+  });
+
+  it('should throw error if deferred script follows a non-deferred one in one block', function () {
+    var htmlcontent = '<!-- build:js foo.js -->\n' +
+    '<script src="bar.js"></script>\n' +
+    '<script defer src="baz.js"></script>\n' +
+    '<!-- endbuild -->';
+    try {
+      new HTMLProcessor('', '', htmlcontent, 3);
+    } catch (e) {
+      assert.ok(true);
+      return;
+    }
+    assert.ok(false);
+  });
+
   it('should detect media attribute', function () {
     var htmlcontent = '<!-- build:css foo.css -->\n' +
     '<link rel="stylesheet" href="foo.css" media="(min-width:980px)">\n' +
@@ -173,6 +211,15 @@ describe('htmlprocessor', function () {
       var hp = new HTMLProcessor('', '', htmlcontent, 3);
       var replacestring = hp.replaceWith(hp.blocks[0]);
       assert.equal('<script src="foo.js"></script>', replacestring);
+    });
+
+    it('should preserve defer attribue (JS)', function () {
+      var htmlcontent = '<!-- build:js foo.js -->\n' +
+      '<script defer src="bar.js"></script>\n' +
+      '<!-- endbuild -->';
+      var hp = new HTMLProcessor('', '', htmlcontent, 3);
+      var replacestring = hp.replaceWith(hp.blocks[0]);
+      assert.equal('<script defer src="foo.js"></script>', replacestring);
     });
 
     it('should return a string that will replace the furnished block (RequireJS)', function () {


### PR DESCRIPTION
Fixes #138.

This patch handle three cases, describe in tests.

As there is no access to `grunt.fail` in `htmlprocesser.js` nor an existing syntax to express errors of a block, I decided the function should simply throw there, in the sprit of "fail early". It would be the most obvious way of failure.

I have read the [pull request guideline](https://github.com/yeoman/yeoman/blob/master/contributing.md#pull-request-guidelines) and submitted CLA, write and pass tests.
