### PR TITLE
Fixing script regex to support script tags on the same line

### DIFF
--- a/lib/fileprocessor.js
+++ b/lib/fileprocessor.js
@@ -6,7 +6,7 @@ var _ = require('lodash');
 var _defaultPatterns = {
 	'html': [
       /*jshint regexp:false */
-      [ /<script.+src=['"]([^"']+)["']/gm,
+      [ /<script(?:[^>]+)src=['"]([^"']+)["']/gm,
       'Update the HTML to reference our concat/min/revved script files'
       ],
       [ /<link[^\>]+href=['"]([^"']+)["']/gm,


### PR DESCRIPTION
This was replacing more than just one script tag because Jade puts the script tags on the same line
