### PR TITLE
V2.0 Support for IE conditionals within block

### DIFF
--- a/lib/file.js
+++ b/lib/file.js
@@ -81,6 +81,15 @@ var getBlocks = function (content) {
         last.searchPath.push(build[2]);
       }
     }
+    // Check IE conditionals
+    var isConditionalStart = l.match(/<!--\[[^\]]+\]>/);
+    var isConditionalEnd = l.match(/<!\[endif\]-->/);
+    if (block && isConditionalStart) {
+      last.conditionalStart = isConditionalStart;
+    }
+    if (block && isConditionalEnd) {
+      last.conditionalEnd = isConditionalEnd;
+    }
 
     // switch back block flag when endbuild
     if (block && endbuild) {

--- a/lib/fileprocessor.js
+++ b/lib/fileprocessor.js
@@ -81,14 +81,15 @@ FileProcessor.prototype.replaceBlocks = function replaceBlocks(file) {
 FileProcessor.prototype.replaceWith = function replaceWith(block) {
   var result;
   var dest = block.dest;
-
+  var conditionalStart = block.conditionalStart ? block.conditionalStart + '\n' + block.indent : '';
+  var conditionalEnd = block.conditionalEnd ? '\n' + block.indent + block.conditionalEnd : '';
   if (block.type === 'css') {
     var media = block.media ? ' media="' + block.media + '"' : '';
-    result = block.indent + '<link rel="stylesheet" href="' + dest + '"' + media + '/>';
+    result = block.indent + conditionalStart + '<link rel="stylesheet" href="' + dest + '"' + media + '/>' + conditionalEnd;
   } else if (block.defer) {
-    result = block.indent + '<script defer src="' + dest + '"><\/script>';
+    result = block.indent + conditionalStart + '<script defer src="' + dest + '"><\/script>' + conditionalEnd;
   } else if (block.type === 'js') {
-    result = block.indent + '<script src="' + dest + '"><\/script>';
+    result = block.indent + conditionalStart + '<script src="' + dest + '"><\/script>' + conditionalEnd;
   } /*else {
     result = '';
   }*/

--- a/test/fixtures/block_with_IEconditionals_inline.html
+++ b/test/fixtures/block_with_IEconditionals_inline.html
@@ -1,0 +1,3 @@
+<!-- build:js javascripts/vendor/selectivizr.js --><!--[if (lt IE 9) & (!IEmobile)]>
+  <script src="javascripts/vendor/selectivizr/selectivizr.js"></script>
+<![endif]--><!-- endbuild -->

--- a/test/fixtures/block_with_IEconditionals_within.html
+++ b/test/fixtures/block_with_IEconditionals_within.html
@@ -1,0 +1,5 @@
+<!-- build:js javascripts/vendor/selectivizr.js -->
+  <!--[if (lt IE 9) & (!IEmobile)]>
+    <script src="javascripts/vendor/selectivizr/selectivizr.js"></script>
+  <![endif]-->
+<!-- endbuild -->

--- a/test/test-file.js
+++ b/test/test-file.js
@@ -57,6 +57,26 @@ describe('File', function() {
     assert.equal(2, b1.src.length);
   });
 
+  it('should also detect block that has IE conditionals on same line', function() {
+    var filename = __dirname + '/fixtures/block_with_IEconditionals_inline.html';
+    var file = new File(filename);
+    assert.equal(1, file.blocks.length);
+    assert.ok(file.blocks[0].conditionalStart);
+    assert.ok(file.blocks[0].conditionalEnd);
+    assert.equal('<!--[if (lt IE 9) & (!IEmobile)]>', file.blocks[0].conditionalStart);
+    assert.equal('<![endif]-->', file.blocks[0].conditionalEnd);
+  });
+
+  it('should also detect block that has IE conditionals within block', function() {
+    var filename = __dirname + '/fixtures/block_with_IEconditionals_within.html';
+    var file = new File(filename);
+    assert.equal(1, file.blocks.length);
+    assert.ok(file.blocks[0].conditionalStart);
+    assert.ok(file.blocks[0].conditionalEnd);
+    assert.equal('<!--[if (lt IE 9) & (!IEmobile)]>', file.blocks[0].conditionalStart);
+    assert.equal('<![endif]-->', file.blocks[0].conditionalEnd);
+  });
+
   it('should throw an exception if it finds RequireJS blocks', function() {
     var filename = __dirname + '/fixtures/requirejs.html';
     assert.throws( function() {

--- a/test/test-fileprocessor.js
+++ b/test/test-fileprocessor.js
@@ -105,33 +105,33 @@ describe('FileProcessor', function() {
       assert.equal(result, '  <link rel="stylesheet" href="foo.css" media="(min-width:980px)"/>');
     });
 
-    // it('should preserve conditional comments', function() {
-    //   var result = fp.replaceWith(block);
-    //   var htmlcontent = '<!-- build:js foo.js -->\n' +
-    //   '<!--[if lte IE 8]>\n' +
-    //   '<script src="bar.js"></script>\n' +
-    //   '<script src="baz.js"></script>\n' +
-    //   '<![endif]-->\n' +
-    //   '<!-- endbuild -->\n';
-    //   var hp = new HTMLProcessor('build', '', htmlcontent, 3);
-    //   var replacestring = hp.replaceWith(hp.blocks[0]);
-    //   assert.equal(replacestring, '<!--[if lte IE 8]>\n<script src="foo.js"></script>\n<![endif]-->');
-    // });
+    it('should preserve IE conditionals for js blocks', function () {
+      var fp = new FileProcessor('html',{});
+      var block = {
+        dest: 'foo.js',
+        type: 'js',
+        conditionalStart: '<!--[if (lt IE 9) & (!IEmobile)]>',
+        conditionalEnd: '<![endif]-->',
+        indent: '  '
+      };
 
-    // it('should preserve conditional comments (non-IE)', function() {
-    //   var htmlcontent = '<!-- build:js foo.js -->\n' +
-    //   '<!--[if gte IE 9]><!-->\n' +
-    //   '<script src="bar.js"></script>\n' +
-    //   '<script src="baz.js"></script>\n' +
-    //   '<!--<![endif]-->\n' +
-    //   '<!-- endbuild -->\n';
-    //   var hp = new HTMLProcessor('build', '', htmlcontent, 3);
-    //   var replacestring = hp.replaceWith(hp.blocks[0]);
-    //   assert.equal(replacestring, '<!--[if gte IE 9]><!-->\n<script src="foo.js"></script>\n<!--<![endif]-->');
-    // });
+      var result = fp.replaceWith(block);
+      assert.equal(result, '  <!--[if (lt IE 9) & (!IEmobile)]>\n  <script src="foo.js"><\/script>\n  <![endif]-->');
+    });
 
+    it('should preserve IE conditionals for css blocks', function () {
+      var fp = new FileProcessor('html',{});
+      var block = {
+        dest: 'foo.css',
+        type: 'css',
+        conditionalStart: '<!--[if (lt IE 9) & (!IEmobile)]>',
+        conditionalEnd: '<![endif]-->',
+        indent: '  '
+      };
 
-
+      var result = fp.replaceWith(block);
+      assert.equal(result, '  <!--[if (lt IE 9) & (!IEmobile)]>\n  <link rel="stylesheet" href="foo.css"/>\n  <![endif]-->');
+    });
 	});
 
 	describe('replaceWithRevved', function() {


### PR DESCRIPTION
Support in V2.0 for IE conditionals within blocks, either on same line
or within the block. No issues found with indentation or positioning.

Added Fixtures and Tests.
