### PR TITLE
Added support for src attributes

### DIFF
--- a/lib/cssprocessor.js
+++ b/lib/cssprocessor.js
@@ -29,17 +29,17 @@ CSSProcessor.prototype.log = function log(msg) {
 //  - replace image references by their revved version
 //
 CSSProcessor.prototype.process = function process() {
-    var self = this;
-    // Replace reference to images with the actual name of the optimized image
-    this.log('Update the CSS with new img filenames');
-    return this.content.replace(/url\(\s*['"]?([^'"\)#?]+)(?:[#?](?:[^'"\)]*))?['"]?\s*\)/gm, function (match, src) {
-      // Consider reference from site root
-      var file = self.revvedfinder.find(src, self.filepath);
-      var res = match.replace(src, file);
+  var self = this;
+  // Replace reference to images with the actual name of the optimized image
+  this.log('Update the CSS with new img filenames');
+  return this.content.replace(/(src=|url\(\s*)['"]?([^'"\)#?]+)(?:[#?](?:[^'"\)]*))?['"]?\s*\)?/gm, function (match, attribute, src) {
+    // Consider reference from site root
+    var file = self.revvedfinder.find(src, self.filepath);
+    var res = match.replace(src, file);
 
-      if (src !== file) {
-        self.log(match + ' changed to ' + res);
-      }
-      return res;
-    });
-  };
+    if (src !== file) {
+      self.log(match + ' changed to ' + res);
+    }
+    return res;
+  });
+};

--- a/test/test-cssprocessor.js
+++ b/test/test-cssprocessor.js
@@ -71,5 +71,12 @@ describe('cssprocessor', function () {
       var awaited = 'background-image:url(fonts/2123.awesome-font.svg?#iefix);';
       assert.equal(awaited, cp.process());
     });
+
+    it('should support src attributes', function () {
+      var content = 'filter: progid:DXImageTransform.Microsoft.AlphaImageLoader(src=\'images/pic.png\',sizingMethod=\'scale\');';
+      var cp = new CSSProcessor('', 'build/css', content, revvedfinder);
+      var awaited = 'filter: progid:DXImageTransform.Microsoft.AlphaImageLoader(src=\'images/2123.pic.png\',sizingMethod=\'scale\');';
+      assert.equal(awaited, cp.process());
+    });
   });
 });


### PR DESCRIPTION
Often in IE 8 when you load some background sized images. You need to use AlphaImageLoader. Though it uses `src` attribute to define the resource url like below:

``` css
.some-class {
  filter: progid:DXImageTransform.Microsoft.AlphaImageLoader(
    src='images/test.jpg',
    sizingMethod='scale'
  );
}
```

`Grunt-usemin` doesn't support `src`attributes right now. I changed the regex and added some test for it. 
