### PR TITLE
Prevented test for defer attribute to match file name in src attribute;

### DIFF
--- a/lib/file.js
+++ b/lib/file.js
@@ -110,7 +110,7 @@ var getBlocks = function (content) {
         }
 
         // preserve defer attribute
-        var defer = /defer/.test(l);
+        var defer = / defer/.test(l);
         if (defer && last.defer === false || last.defer && !defer) {
           throw new Error('Error: You are not suppose to mix deferred and non-deferred scripts in one block.');
         } else if (defer) {

--- a/test/fixtures/block_with_fake_defer_in_path.html
+++ b/test/fixtures/block_with_fake_defer_in_path.html
@@ -1,0 +1,3 @@
+<!-- build:js foo.js -->
+  <script src="defer.js"></script>
+<!-- endbuild -->

--- a/test/test-file.js
+++ b/test/test-file.js
@@ -110,6 +110,14 @@ describe('File', function() {
     assert.equal(true, file.blocks[0].defer);
   });
 
+  it('should not detect the defer string in file path', function () {
+    var filename = __dirname + '/fixtures/block_with_fake_defer_in_path.html';
+    var file = new File(filename);
+    assert.equal(1, file.blocks.length);
+    assert.ok(!file.blocks[0].defer);
+    assert.equal(false, file.blocks[0].defer);
+  });
+
   it('should throw error if non-deferred script follows a deferred one in one block', function () {
     var filename = __dirname + '/fixtures/block_with_mixed_defer.html';
     try {


### PR DESCRIPTION
The current test for defer attribute match the following:
`<script src="path/containing/defer-keyword.js"></script>`
I added a space character as a prefix to avoid matching a file path unexpectedly.
Unit-test included.
