### PR TITLE
Support multiple targets in useminPrepare

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,19 @@ If you need to change the 'root' dir, use the `root` option (see bellow).
 }
 ```
 
+Targets can also be configured using the grunt src-dest files syntax http://gruntjs.com/configuring-tasks#files, e.g.
+
+```js
+useminPrepare: {
+  foo: {
+    src: ['index.html', 'another.html']
+  },
+  bar: {
+    src: 'index.html'
+  }
+}
+```
+
 ### Options
 
 ### dest

--- a/tasks/usemin.js
+++ b/tasks/usemin.js
@@ -140,12 +140,11 @@ module.exports = function (grunt) {
   grunt.registerMultiTask('useminPrepare', 'Using HTML markup as the primary source of information', function () {
     var options = this.options();
     // collect files
-    var files = grunt.file.expand({filter: 'isFile'}, this.data);
     var dest = options.dest || 'dist';
     var root = options.root;
 
     grunt.log
-      .writeln('Going through ' + grunt.log.wordlist(files) + ' to update the config')
+      .writeln('Going through ' + grunt.log.wordlist(this.filesSrc) + ' to update the config')
       .writeln('Looking for build script HTML comment blocks');
 
     var flow = getFlowFromConfig(grunt.config('useminPrepare'), this.target);
@@ -160,7 +159,7 @@ module.exports = function (grunt) {
       gruntConfig[name] = grunt.config(name) || {};
     });
 
-    files.forEach(function (filepath) {
+    this.filesSrc.forEach(function (filepath) {
       var config;
       try {
         config = c.process(filepath, grunt.config());


### PR DESCRIPTION
Inspired by #162. I tried that pull request locally but it didn't work. I guess it was broken when @trask squashed the commits (I can see some discussion with @sindresorhus on lines which were not in the squashed commit there). :(

I also looked at the first pull request from @trask, #143, and there were too much unnecessary changes IMHO. This pull request just gets the files list from `this.filesSrc`.
