### PR TITLE
feature: Optional configuration target

### DIFF
--- a/lib/configwriter.js
+++ b/lib/configwriter.js
@@ -153,16 +153,18 @@ ConfigWriter.prototype.process = function(file, config) {
       context.inDir = block.searchPath[0];
     }
     self.forEachStep(block.type, function(writer, last) {
+      // Use the default 'generated' target unless a configuration target was specified
+      var target = block.target || 'generated';
 
       // If this is the last writer of the pipe, we need to output
       // in the destination directory
       context.outDir = last ? self.dest : path.join(self.staging, writer.name);
       context.last = last;
       config[writer.name] = config[writer.name] || {};
-      config[writer.name].generated = config[writer.name].generated || {};
+      config[writer.name][target] = config[writer.name][target] || {};
       context.options = config[writer.name];
-      // config[writer.name].generated = _.extend(config[writer.name].generated, writer.createConfig(context, block));
-      config[writer.name].generated = deepMerge(config[writer.name].generated, writer.createConfig(context, block));
+      // config[writer.name][target] = _.extend(config[writer.name][target], writer.createConfig(context, block));
+      config[writer.name][target] = deepMerge(config[writer.name][target], writer.createConfig(context, block));
       context.inDir = context.outDir;
       context.inFiles = context.outFiles;
       context.outFiles = [];

--- a/lib/file.js
+++ b/lib/file.js
@@ -35,15 +35,20 @@ var fs = require('fs');
 //
 var getBlocks = function (content) {
   // start build pattern: will match
-  //  * <!-- build:[target] output -->
-  //  * <!-- build:[target](alternate search path) output -->
+  //  * <!-- build:[type] output -->
+  //  * <!-- build:[type]:[target] output -->
+  //  * <!-- build:[type](alternate search path) output -->
+  //  * <!-- build:[type]:[target](alternate search path) output -->
+
   // The following matching param are set when there's match
   //   * 0 : the whole matched expression
-  //   * 1 : the target (ie. type)
-  //   * 2 : the alternate search path
-  //   * 3 : the output
+  //   * 1 : the type (ie. js, css)
+  //   * 2 : an optional configuration target
+  //   * 3 : the alternate search path
+  //   * 4 : the output
   //
-  var regbuild = /<!--\s*build:(\w+)(?:\(([^\)]+)\))?\s*([^\s]+)\s*-->/;
+  var regbuild = /<!--\s*build:(\w+)(?::(\w+))?(?:\(([^\)]+)\))?\s*([^\s]+)\s*-->/;
+
   // end build pattern -- <!-- endbuild -->
   var regend = /<!--\s*endbuild\s*-->/;
 
@@ -62,13 +67,13 @@ var getBlocks = function (content) {
     if (build) {
       block = true;
       // Handle absolute path (i.e. with respect to the server root)
-      // if (build[3][0] === '/') {
+      // if (build[4][0] === '/') {
       //   startFromRoot = true;
-      //   build[3] = build[3].substr(1);
+      //   build[4] = build[4].substr(1);
       // }
       last = {
         type: build[1],
-        dest: build[3],
+        dest: build[4],
         startFromRoot: startFromRoot,
         indent: indent,
         searchPath: [],
@@ -77,8 +82,13 @@ var getBlocks = function (content) {
       };
 
       if (build[2]) {
+        // Optional configuration target
+        last.target = build[2];
+      }
+
+      if (build[3]) {
         // Alternate search path
-        last.searchPath.push(build[2]);
+        last.searchPath.push(build[3]);
       }
     }
     // Check IE conditionals

--- a/test/fixtures/optional_configuration_target.html
+++ b/test/fixtures/optional_configuration_target.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+    <head>
+        <link rel="stylesheet" href="styles/main.css">
+        <script src="scripts/vendor/modernizr.min.js"></script>
+    </head>
+    <body>
+
+    <!-- build:js:thirdparty scripts/thirdparty.js -->
+    <script src="scripts/bar.js"></script>
+    <script src="scripts/baz.js"></script>
+    <!-- endbuild -->
+</body>
+</html>

--- a/test/test-file.js
+++ b/test/test-file.js
@@ -148,5 +148,12 @@ describe('File', function() {
     assert.equal('(min-width:980px)', file.blocks[0].media);
   });
 
+  it('should detect an optional configuration target', function() {
+    var filename = __dirname + '/fixtures/optional_configuration_target.html';
+    var file = new File(filename);
+    assert.equal(1, file.blocks.length);
+    assert.ok(file.blocks[0].target);
+    assert.equal('thirdparty', file.blocks[0].target);
+  });
 
 });


### PR DESCRIPTION
In usemin 2.0.0 the configurations targets for all blocks are set to the 'generated' namespace. This makes it difficult to target individual blocks especially when using multiple of one type. Our current project is quite large and I like to keep my main source libs and vendor libs separated and use different uglify options on each js block, 1) to speed up build by not compressing/mangling concatenated vendor libs which come pre minified and 2) specifying preserveComments as many libs like JQuery include License comment banners which are required by copyright law (I know most people just strip these out anyways).

The included patch allows for including an optional configuration target in the html block like so:

``` html
    <!-- build:js:thirdparty assets/libs.js -->
    <script src="/lib/modernizr.js"></script>
    <script src="/components/jquery/jquery.min.js"></script>
    <script src="/components/underscore/underscore-min.js"></script>
    <!-- endbuild -->

    <!-- build:js:application assets/app.js -->
    <script src="/src/main.js"></script>
    <script src="/src/a.js"></script>
    <script src="/src/b.js"></script>
    <script src="/src/c.js"></script>
    <!-- endbuild -->
```

Now i rather than everything under the 'generated' target i have 'thirdparty' and 'application' and now I can easily specify custom uglify options for my vendor libs. Simple whitespace removal..

``` coffeescript
    uglify:
      thirdparty:
        options:
          compress: false
          mangle: false
          preserveComments: 'all'
```

I could even choose to exclude uglify of this js target altogether and only include 'uglify:application' in my build steps.

If you do not specify a target it will use the default 'generated'.

In the future it would be nice to take this a step further and allow for custom flows per target per type as well. 

I welcome any feedback.
