### PR TITLE
Makes quotes optional for inlined background url

### DIFF
--- a/lib/fileprocessor.js
+++ b/lib/fileprocessor.js
@@ -43,7 +43,7 @@ var _defaultPatterns = {
       /data-(?!main).[^=]+=['"]([^'"]+)['"]/gm,
       'Update the HTML with data-* tags'
     ],
-    [ 
+    [
       /url\(\s*['"]?([^"'\)]+)["']?\s*\)/gm,
       'Update the HTML with background imgs, case there is some inline style'
     ],

--- a/test/test-fileprocessor.js
+++ b/test/test-fileprocessor.js
@@ -367,10 +367,10 @@ describe('FileProcessor', function () {
     });
 
     it('should replace unquoted image reference in inlined style', function () {
-          var content = '<li style="background: url(image.png);"></li>';
-          var replaced = fp.replaceWithRevved(content, ['app']);
-          assert.equal(replaced, '<li style="background: url(' + filemapping['app/image.png'] + ');"></li>');
-        });
+      var content = '<li style="background: url(image.png);"></li>';
+      var replaced = fp.replaceWithRevved(content, ['app']);
+      assert.equal(replaced, '<li style="background: url(' + filemapping['app/image.png'] + ');"></li>');
+    });
 
     it('should replace image reference in anchors', function () {
       var content = '<a href="image.png"></a>';


### PR DESCRIPTION
I noticed that this regex was not swapping out some image references in a project that I am working on. The reason was some inlined css that did not use quotes for background images. So I have modified the regex to work like the one for processing css. 
