### PR TITLE
Properly handle search and hash URL components in FileProcessor

### DIFF
--- a/lib/fileprocessor.js
+++ b/lib/fileprocessor.js
@@ -2,6 +2,7 @@
 var debug = require('debug')('fileprocessor');
 var File = require('./file');
 var _ = require('lodash');
+var url = require('url')
 
 var _defaultPatterns = {
 	'html': [
@@ -115,18 +116,28 @@ FileProcessor.prototype.replaceWithRevved = function replaceWithRevved(lines, as
       self.log(rxl[1]);
       content = content.replace(rxl[0], function (match, src) {
         // Consider reference from site root
-        var srcfile = filterIn(src);
+        var srcUrl = url.parse(filterIn(src));
+        var srcQuery = srcUrl.search;
+        var srcHash = srcUrl.hash;
+        srcUrl.search = '';
+        srcUrl.hash = '';
+        var srcFile = url.format(srcUrl);
 
         debug('Let\'s replace ' + src);
 
-        debug('Looking for revved version of ' + srcfile + ' in ', assetSearchPath);
+        debug('Looking for revved version of ' + srcFile + ' in ', assetSearchPath);
 
-        var file = self.finder.find(srcfile, assetSearchPath);
+        var file = self.finder.find(srcFile, assetSearchPath);
 
         debug('Found file \'%s\'', file);
 
-        var res = match.replace(src, filterOut(file));
-        if (srcfile !== file) {
+        var outUrl = url.parse(filterOut(file));
+        outUrl.search = srcQuery;
+        outUrl.hash = srcHash;
+        var outFile = url.format(outUrl);
+        var res = match.replace(src, outFile);
+
+        if (match !== res) {
           self.log(match + ' changed to ' + res);
         }
         return res;


### PR DESCRIPTION
Strip them off before searching for the filename, and restore them after transforming it.

Especially useful for third-party CSS like `url('../font/fontawesome-webfont.eot?v=3.2.1')`.
