### PR TITLE
Fixing #221 & #234 where question mark followed by fragment identifier in custom font urls prevents revving.

### DIFF
--- a/lib/fileprocessor.js
+++ b/lib/fileprocessor.js
@@ -35,7 +35,7 @@ var _defaultPatterns = {
     ],
 	  'css': [
       /*jshint regexp:false */
-      [ /(?:src=|url\(\s*)['"]?([^'"\)]+)['"]?\s*\)?/gm,
+      [ /(?:src=|url\(\s*)['"]?([^'"\)\?]+)['"]?\s*\)?/gm,
       'Update the CSS to reference our revved images'
       ]
     ]

--- a/test/test-fileprocessor.js
+++ b/test/test-fileprocessor.js
@@ -379,5 +379,33 @@ describe('FileProcessor', function() {
 
 		    });
     });
+
+    describe('font path', function() {
+      var content = '@font-face {\nfont-family:"icons";\nsrc:url("/styles/fonts/icons.eot");\nsrc:url("/styles/fonts/icons.eot?#iefix") format("embedded-opentype"),\nurl("/styles/fonts/icons.woff") format("woff"),\nurl("/styles/fonts/icons.ttf") format("truetype"),\nurl("/styles/fonts/icons.svg?#icons") format("svg");\nfont-weight:normal;\nfont-style:normal;\n}';
+      var filemapping = {
+        'build/styles/fonts/icons.eot': '/styles/fonts/icons.12345.eot',
+        'build/styles/fonts/icons.woff': '/styles/fonts/icons.12345.woff',
+        'build/styles/fonts/icons.ttf': '/styles/fonts/icons.12345.ttf',
+        'build/styles/fonts/icons.svg': '/styles/fonts/icons.12345.svg',
+      };
+
+      var revvedfinder = helpers.makeFinder(filemapping);
+
+      beforeEach(function() {
+        cp = new FileProcessor('css', revvedfinder);
+      });
+
+      it('should replace but ignore querystrings on revved files when found', function(){
+        var changed = cp.replaceWithRevved(content, ['build']);
+
+        assert.ok(changed.match(/\/styles\/fonts\/icons\.12345\.eot/));
+        assert.ok(changed.match(/\/styles\/fonts\/icons\.12345\.woff/));
+        assert.ok(changed.match(/\/styles\/fonts\/icons\.12345\.ttf/));
+        assert.ok(changed.match(/\/styles\/fonts\/icons\.12345\.svg/));
+      });
+
+    });
+
+
 	});
 });


### PR DESCRIPTION
Custom fonts often have the following "bulletproof" (http://www.fontspring.com/blog/the-new-bulletproof-font-face-syntax) output which doesn't work when rev'ving the font files.

This fixes it by allowing by adding a question mark to the regex.

``` css
src:url("/styles/fonts/icons.eot");
src:url("/styles/fonts/icons.eot?#iefix") format("embedded-opentype"),
    url("/styles/fonts/icons.woff") format("woff"),
    url("/styles/fonts/icons.ttf") format("truetype"),
    url("/styles/fonts/icons.svg?#icons") format("svg”);
```
