### PR TITLE
fixed configwriter to process post config (incl test and docu)

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,11 +175,37 @@ For example:
       options: {
         flow: {
           steps: {'js' : ['uglifyjs'] },
-          post: []
+          post: {}
         }
       }
     }
 ```
+
+* to customize the generated configuraion via post-processors:
+
+```js
+'useminPrepare', {
+      html: 'index.html',
+      options: {
+        flow: {
+          steps: {'js' : ['uglifyjs'] },
+          post: {
+            'js': [{
+              name: 'uglifyjs',
+              createConfig: function(context, block) {
+                  var generated = context.options.generated;
+                  generated.options = {
+                      foo: 'bar'
+                  };
+              }
+            }]
+          }
+        }
+      }
+    }
+}
+```
+
 The given steps or post-processors may be specified as strings (for the default steps and post-processors), or as an object (for the user-defined ones).
 
 #### User-defined steps and post-processors

--- a/lib/configwriter.js
+++ b/lib/configwriter.js
@@ -176,13 +176,14 @@ ConfigWriter.prototype.process = function(file, config) {
     }
     context.inFiles = block.src;
 
-    self.postprocessors.forEach(function(pp) {
-      config[pp.name] = config[pp.name] || {};
-      context.options = config[pp.name];
-      config[pp.name] = _.extend(config[pp.name], pp.createConfig(context, block));
-      context.options = null;
-
-    });
+    if(self.postprocessors.hasOwnProperty(block.type)) {
+      self.postprocessors[block.type].forEach(function(pp) {
+        config[pp.name] = config[pp.name] || {};
+        context.options = config[pp.name];
+        config[pp.name] = _.extend(config[pp.name], pp.createConfig(context, block));
+        context.options = null;
+      });
+    }
   });
 
   return config;

--- a/test/test-usemin.js
+++ b/test/test-usemin.js
@@ -439,7 +439,7 @@ describe('useminPrepare', function () {
       options: {
         flow: {
           steps: {'js': ['uglifyjs']},
-          post: []
+          post: {}
         }
       }
     });
@@ -469,7 +469,7 @@ describe('useminPrepare', function () {
         flow: {
           'html': {
             steps: {'js': ['uglifyjs']},
-            post: []
+            post: {}
           }
         }
       }
@@ -511,7 +511,7 @@ describe('useminPrepare', function () {
       options: {
         flow: {
             steps: {'js': [copy]},
-            post: []
+            post: {}
           }
         }
       });
@@ -524,5 +524,44 @@ describe('useminPrepare', function () {
     assert.ok(copyCfg);
     assert.equal(copyCfg.generated.files[0].dest, path.normalize('dist/scripts/plugins.js'));
   });
-});
 
+  it('should allow to post configure generated steps', function() {
+
+    var concatPostConfig = {
+        name: 'concat',
+        createConfig: function(context) {
+            var generated = context.options.generated;
+            generated.options = {
+                foo: 'bar'
+              };
+          }
+      };
+
+    grunt.log.muted = true;
+    grunt.config.init();
+    grunt.config('useminPrepare', {
+        html: 'index.html',
+        options: {
+            flow: {
+                steps: {'js': ['concat']},
+                post: {
+                    'js': [
+                        concatPostConfig
+                      ]
+                    }
+                  }
+                }
+              });
+
+    grunt.file.copy(path.join(__dirname, 'fixtures/usemin.html'), 'index.html');
+    grunt.task.run('useminPrepare');
+    grunt.task.start();
+
+    var concatCfg = grunt.config('concat');
+    var options = concatCfg.generated.options;
+
+    assert.ok(options);
+    assert.equal(options.foo, 'bar');
+
+  });
+});


### PR DESCRIPTION
There is a bug in the configwriter which causes the problem that configured post-processor get ignored. 
This pull request fixes this issue. See also #245

I also provided some docu about configuring post-processor and added a test case for that. 

Feel free to merge.
