### PR TITLE
Add support for content on same line as block start/end

### DIFF
--- a/lib/file.js
+++ b/lib/file.js
@@ -39,11 +39,12 @@ var getBlocks = function (content) {
   //  * <!-- build:[target](alternate search path) output -->
   // The following matching param are set when there's a match
   //   * 0 : the whole matched expression
-  //   * 1 : the target (i.e. type)
-  //   * 2 : the alternate search path
-  //   * 3 : the output
+  //   * 1 : the indent
+  //   * 2 : the target (i.e. type)
+  //   * 3 : the alternate search path
+  //   * 4 : the output
   //
-  var regbuild = /<!--\s*build:(\w+)(?:\(([^\)]+)\))?\s*([^\s]+)\s*-->/;
+  var regbuild = /(^\s+)?<!--\s*build:(\w+)(?:\(([^\)]+)\))?\s*([^\s]+)\s*-->/;
   // end build pattern -- <!-- endbuild -->
   var regend = /<!--\s*endbuild\s*-->/;
 
@@ -53,32 +54,32 @@ var getBlocks = function (content) {
   var last;
 
   lines.forEach(function (l) {
-    var indent = (l.match(/^\s*/) || [])[0];
     var build = l.match(regbuild);
-    var endbuild = regend.test(l);
+    var endbuild = l.match(regend);
     var startFromRoot = false;
 
     // discard empty lines
     if (build) {
       block = true;
       // Handle absolute path (i.e. with respect to the server root)
-      // if (build[3][0] === '/') {
+      // if (build[4][0] === '/') {
       //   startFromRoot = true;
-      //   build[3] = build[3].substr(1);
+      //   build[4] = build[4].substr(1);
       // }
       last = {
-        type: build[1],
-        dest: build[3],
+        type: build[2],
+        dest: build[4],
         startFromRoot: startFromRoot,
-        indent: indent,
+        startIndex: build.index,
+        indent: build[1] || '',
         searchPath: [],
         src: [],
         raw: []
       };
 
-      if (build[2]) {
+      if (build[3]) {
         // Alternate search path
-        last.searchPath.push(build[2]);
+        last.searchPath.push(build[3]);
       }
     }
     // Check IE conditionals
@@ -89,13 +90,6 @@ var getBlocks = function (content) {
     }
     if (block && isConditionalEnd) {
       last.conditionalEnd = isConditionalEnd;
-    }
-
-    // switch back block flag when endbuild
-    if (block && endbuild) {
-      last.raw.push(l);
-      sections.push(last);
-      block = false;
     }
 
     if (block && last) {
@@ -140,6 +134,16 @@ var getBlocks = function (content) {
           throw new Error('require.js blocks are no more supported.');
         }
       }
+    }
+
+    // switch back block flag when endbuild
+    if (block && endbuild) {
+      last.endIndex = endbuild.index + endbuild[0].length - l.length;
+      sections.push(last);
+      block = false;
+    }
+
+    if (block || endbuild) {
       last.raw.push(l);
     }
   });

--- a/lib/fileprocessor.js
+++ b/lib/fileprocessor.js
@@ -154,7 +154,9 @@ FileProcessor.prototype.replaceBlocks = function replaceBlocks(file) {
   var linefeed = /\r\n/g.test(result) ? '\r\n' : '\n';
   file.blocks.forEach(function (block) {
     var blockLine = block.raw.join(linefeed);
-    result = result.replace(blockLine, this.replaceWith(block));
+    var prefix = blockLine.slice(0, block.startIndex);
+    var suffix = block.endIndex ? blockLine.slice(block.endIndex) : '';
+    result = result.replace(blockLine, prefix + this.replaceWith(block) + suffix);
   }, this);
   return result;
 };

--- a/test/fixtures/block_on_one_line.html
+++ b/test/fixtures/block_on_one_line.html
@@ -1,0 +1,1 @@
+<!-- build:js foo.js --><script src="bar.js"></script><!-- endbuild -->

--- a/test/fixtures/block_with_script_on_end_line.html
+++ b/test/fixtures/block_with_script_on_end_line.html
@@ -1,0 +1,2 @@
+<!-- build:js foo.js -->
+<script src="bar.js"></script><!-- endbuild -->

--- a/test/fixtures/block_with_script_on_start_line.html
+++ b/test/fixtures/block_with_script_on_start_line.html
@@ -1,0 +1,2 @@
+<!-- build:js foo.js --><script src="bar.js"></script>
+<!-- endbuild -->

--- a/test/test-file.js
+++ b/test/test-file.js
@@ -167,5 +167,37 @@ describe('File', function () {
     assert.equal('(min-width:980px)', file.blocks[0].media);
   });
 
+  it('should detect a block that has a script on the start line', function () {
+    var filename = __dirname + '/fixtures/block_with_script_on_start_line.html';
+    var file = new File(filename);
+    assert.equal(1, file.blocks.length);
+
+    var block = file.blocks[0];
+    assert.equal('js', block.type);
+    assert.equal(2, block.raw.length);
+    assert.equal(1, block.src.length);
+  });
+
+  it('should detect a block that has a script on the end line', function () {
+    var filename = __dirname + '/fixtures/block_with_script_on_start_line.html';
+    var file = new File(filename);
+    assert.equal(1, file.blocks.length);
+
+    var block = file.blocks[0];
+    assert.equal('js', block.type);
+    assert.equal(2, block.raw.length);
+    assert.equal(1, block.src.length);
+  });
+
+  it('should detect a block on a single line', function () {
+    var filename = __dirname + '/fixtures/block_on_one_line.html';
+    var file = new File(filename);
+    assert.equal(1, file.blocks.length);
+
+    var block = file.blocks[0];
+    assert.equal('js', block.type);
+    assert.equal(1, block.raw.length);
+    assert.equal(1, block.src.length);
+  });
 
 });

--- a/test/test-fileprocessor.js
+++ b/test/test-fileprocessor.js
@@ -45,11 +45,27 @@ describe('FileProcessor', function () {
       var file = {
         content: 'foo\nbar\nbaz\n',
         blocks: [{
-          raw: ['bar', 'baz']
+          raw: ['bar', 'baz'],
+          startIndex: 0
         }]
       };
       var result = fp.replaceBlocks(file);
       assert.equal(result, 'foo\nfoo\n');
+    });
+
+    it('should not remove content before or after the block', function () {
+      var fp = new FileProcessor('html', [], {});
+      fp.replaceWith = function () { return 'foo'; };
+      var file = {
+        content: 'bar\nbefore blockstart\ncontent\nblockend after\nbaz',
+        blocks: [{
+          raw: ['before blockstart', 'content', 'blockend after'],
+          startIndex: 7,
+          endIndex: -6
+        }]
+      };
+      var result = fp.replaceBlocks(file);
+      assert.equal(result, 'bar\nbefore foo after\nbaz');
     });
   });
 


### PR DESCRIPTION
This is particularly useful when using a templating language that does not prettify whitespace.

Basically, the change involves recording the index from the start of the first line of a block at which the block's opening tag starts, and the index *from the end* of the last line of a block at which the block's closing tag ends.  Then, when replacing the `blockLine` in the `FileProcessor#replaceBlocks` we wrap the replacement with the content before the block start and after the block end.

The new tests demonstrate what is now supported, and only one existing test needed changed (needed to specify `startIndex` or else the entire string is re-inserted, as `'string'.slice(undefined) == 'string'`).