### PR TITLE
Extending config format for user-defined flow steps

### DIFF
--- a/lib/configwriter.js
+++ b/lib/configwriter.js
@@ -5,7 +5,7 @@ var _ = require('lodash');
 
 var deepMerge = function(origCfg, cfg) {
   return _.merge(origCfg, cfg, function(a, b) {
-    return _.isArray(a) ? _.union(a, b) : undefined;
+    return _.isArray(a) ? _.union(a||[], b||[]) : undefined;
   });
 };
 

--- a/lib/configwriter.js
+++ b/lib/configwriter.js
@@ -4,15 +4,9 @@ var File = require('./file');
 var _ = require('lodash');
 
 var deepMerge = function(origCfg, cfg) {
-  var outCfg = origCfg;
-
-  if (origCfg.files && cfg.files) {
-    outCfg.files = _.union(origCfg.files, cfg.files);
-  } else if (cfg.files) {
-    outCfg.files = cfg.files;
-  }
-
-  return outCfg;
+  return _.merge(origCfg, cfg, function(a, b) {
+    return _.isArray(a) ? _.union(a, b) : undefined;
+  });
 };
 
 //


### PR DESCRIPTION
Hi,

I use custom step for js handling. Plugin (jsmin-sourcemap) demands configuration in format {dest: [], src: []}. deepMerge function truncate anything except { files: [] } through. I extended it slightly (only for arrays too through). I'd like to see this issue fixed in main repository, so I could reference in packages to it but not to my github repo; if there's additional adjustments that should be done please let me know.

(example how I use it:
```js
var jsminUsemin = {
    name: 'jsmin-sourcemap',
    createConfig: function(context, block) {
      var cfg = {dest: [], src: []};
      var outfile = block.dest;
      cfg.dest = path.join(context.outDir, outfile);
      context.inFiles.forEach(function(f) { cfg.src.push(path.join(context.inDir, f)); } );
      context.outFiles = [block.dest];
      return cfg;
    }
  };

...

useminPrepare: {
      html: 'app/index.html',
      options: {
        root: 'app',
        dest: 'dist/app',
        flow: {
          html: {
            steps: {
              js: [jsminUsemin],
              css: ['cssmin']
            },
            post: {}
          }

        }
      }
    },
```

Thanks,
Igor