### PR TITLE
useminPrepare accepts array of root directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ Base directory where the temporary files should be output (e.g. concatenated fil
 
 ### root
 
-Type: 'string'
+Type: 'string' or 'Array'
 Default: `nil`
 
 The root directory from which your files will be resolved.

--- a/lib/config/concat.js
+++ b/lib/config/concat.js
@@ -1,5 +1,6 @@
 'use strict';
 var path = require('path');
+var fs = require('fs');
 
 exports.name = 'concat';
 
@@ -18,7 +19,23 @@ exports.createConfig = function(context, block) {
   var files = {};
   files.dest = outfile;
   files.src = [];
-  context.inFiles.forEach(function(f) { files.src.push(path.join(context.inDir, f));} );
+
+  context.inFiles.forEach(function(f) {
+    if(Array.isArray(context.inDir)) {
+      context.inDir.every(function(d) {
+        var joinedPath = path.join(d, f);
+        var joinedPathExists = fs.existsSync(joinedPath);
+        if(joinedPathExists) {
+          files.src.push(joinedPath);
+        }
+        return !joinedPathExists;
+      });
+    }
+    else {
+      files.src.push(path.join(context.inDir, f));
+    }
+  });
+
   cfg.files.push(files);
   context.outFiles = [block.dest];
   return cfg;


### PR DESCRIPTION
Added the option set an array of `root` directories for `useminPrepare`.

Use case:
I often use `grunt-contrib-connect` as my local static file server while development. `grunt-contrib-connect` let me set an array of `base` path which will be used as the root for all files. In this way I can logically separate my own source files and vendor files (e.g. `bower_components`) in my file system, but my web server thinks they are in the same root.
