### PR TITLE
Ignore extra characters at filename end in search

### DIFF
--- a/lib/revvedfinder.js
+++ b/lib/revvedfinder.js
@@ -47,9 +47,10 @@ RevvedFinder.prototype.getCandidatesFromMapping = function(file, searchPaths) {
 }
 ;
 RevvedFinder.prototype.getCandidatesFromFS = function(file, searchPaths) {
-  var extname = path.extname(file);
-  var basename = path.basename(file, extname);
-  var dirname = path.dirname(file);
+  var cleanFile = file.replace(/\?.*$/, '');
+  var extname = path.extname(cleanFile);
+  var basename = path.basename(cleanFile, extname);
+  var dirname = path.dirname(cleanFile);
   var hex = '[0-9a-fA-F]+';
   var regPrefix = '(' + hex + '\\.' + regexpQuote(basename) + ')';
   var regSuffix = '('+ regexpQuote(basename) + '\\.' + hex + regexpQuote(extname) + ')';

--- a/test/test-revvedfinder.js
+++ b/test/test-revvedfinder.js
@@ -37,6 +37,14 @@ describe('RevvedFinder', function () {
         assert.equal('image.2345.png', rfile );
       });
 
+      it('should ignore extra characters on the given file', function () {
+        var rf = new RevvedFinder(function () {
+          return ['./image.2345.png'];
+        });
+        var rfile = rf.find('image.png?v=1.4.1', '.');
+        assert.equal('image.2345.png', rfile );
+      });
+
       it('should return revved version of the given file (prefix)', function () {
         var rf = new RevvedFinder(function () {
           return ['./2345.image.png'];


### PR DESCRIPTION
When working with certain bower assets (esp. webfonts). CSS paths may include extra characters intended to promote wide cross-browser compatibility and may not relate to the actual file on the file system. e.g.

``` css
//https://github.com/driftyco/ionicons/blob/v1.4.1/css/ionicons.css#L7
@font-face { font-family: "Ionicons"; src: url("../fonts/ionicons.eot?v=1.4.1"); src: url("../fonts/ionicons.eot?v=1.4.1#iefix") format("embedded-opentype"), url("../fonts/ionicons.ttf?v=1.4.1") format("truetype"), url("../fonts/ionicons.woff?v=1.4.1") format("woff"), url("../fonts/ionicons.svg?v=1.4.1#Ionicons") format("svg"); font-weight: normal; font-style: normal; }
```

In this case, the file name `../fonts/ionicons.eot?v=1.4.1` contains the suffix `?v=1.4.1`. The actual file the revved finder needs to find is `ionicons.eot`. When the revvedfinder runs `path.extname` and `path.basename` on this file name. The extname is assigned `.1` and the basename is assigned `ionicons.eot?v=1.4`. The file is not found, and not replaced in usemin. Eventually causing builds to contain incorrectly referenced font paths. 

```
> var path = require('path');
undefined
> var filename = '../../ionicons.css?v=1.4.1';
undefined
> var extname = path.extname(filename)
undefined
> extname
'.1'
> var basename = path.basename(filename, extname)
undefined
> basename
'ionicons.css?v=1.4'
```

This PR will preprocess the filename to remove these characters so that revvedfinder can find the file.

Relevant: https://github.com/yeoman/yeoman/issues/824#issuecomment-36075384 
