### PR TITLE
enhanced source path resolution for useminPrepare

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ Base directory where the temporary files should be output (e.g. concatenated fil
 
 ### root
 
-Type: 'string'
+Type: 'string' or 'Array'
 Default: `nil`
 
 The root directory from which your files will be resolved.

--- a/README.md
+++ b/README.md
@@ -182,6 +182,14 @@ For example:
 ```
 The given steps or post-processors may be specified as strings (for the default steps and post-processors), or as an object (for the user-defined ones).
 
+### warnMissing
+
+Type: 'boolean'
+Default: `nil`
+
+Whether usemin should issue a warning when it can't find one of the sources
+referenced in a block. For backwards compatibility, this is off by default.
+
 #### User-defined steps and post-processors
 
 User-defined steps and post-processors must have 2 attributes:

--- a/README.md
+++ b/README.md
@@ -190,6 +190,59 @@ Default: `nil`
 Whether usemin should issue a warning when it can't find one of the sources
 referenced in a block. For backwards compatibility, this is off by default.
 
+### resolveSource
+
+Type: 'function'
+Default: `nil`
+
+This is an optional hook allowing applications to override how source urls
+are resolved to filesystem paths. This function is called with the signature
+`resolveSource(sourceUrl, fileDir, fileName, blockTarget, searchPath)`. It should
+return the path to the source file, `null` to indicate the default resolution
+rules should be used, or `false` to indicate the file cannot be resolved.
+
+`sourceUrl` is the source reference being resolved, `fileDir` and `fileName`
+are the directory and name of the file the reference was found in,
+`blockTarget` is the target path for the block the reference occurred within,
+and `searchPath` is an array of the directories that would be searched by default.
+
+For example:
+
+* To override a specific URL prefix, and use the default behavior for all others:
+
+```js
+'useminPrepare', {
+    options: {
+        resolveSource: function (sourceUrl, fileDir, fileName, blockTarget, searchPath) {
+            var fs = require('fs'), path = require('path');
+            var m = sourceUrl.match(/^\/alt-static-url\/(.*)/);
+            if(m){
+                var source = path.join("alt-static-location", m[1]);
+                if(fs.exists(source)) { return source; }
+            }
+            return null;
+        }
+    }
+}
+```
+
+* To replicate the default behavior:
+
+```js
+'useminPrepare', {
+    options: {
+        resolveSource: function (sourceUrl, fileDir, fileName, blockTarget, searchPath) {
+            var fs = require('fs'), path = require('path');
+            for (var i=0; i< searchPath.length; ++i) {
+              var source = path.join(searchPath[i], fname);
+              if (fs.exists(source)) { return source; }
+            }
+            return false;
+        }
+    }
+}
+```
+
 #### User-defined steps and post-processors
 
 User-defined steps and post-processors must have 2 attributes:

--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ For example:
             var m = sourceUrl.match(/^\/alt-static-url\/(.*)/);
             if(m){
                 var source = path.join("alt-static-location", m[1]);
-                if(fs.exists(source)) { return source; }
+                if(fs.existsSync(source)) { return source; }
             }
             return null;
         }
@@ -235,7 +235,7 @@ For example:
             var fs = require('fs'), path = require('path');
             for (var i=0; i< searchPath.length; ++i) {
               var source = path.join(searchPath[i], fname);
-              if (fs.exists(source)) { return source; }
+              if (fs.existsSync(source)) { return source; }
             }
             return false;
         }

--- a/lib/config/concat.js
+++ b/lib/config/concat.js
@@ -17,8 +17,7 @@ exports.createConfig = function(context, block) {
   // Depending whether or not we're the last of the step we're not going to output the same thing
   var files = {};
   files.dest = outfile;
-  files.src = [];
-  context.inFiles.forEach(function(f) { files.src.push(path.join(context.inDir, f));} );
+  files.src = context.inFiles.map(context.resolveInFile, context);
   cfg.files.push(files);
   context.outFiles = [block.dest];
   return cfg;

--- a/lib/config/cssmin.js
+++ b/lib/config/cssmin.js
@@ -17,8 +17,7 @@ exports.createConfig = function(context, block) {
   // Depending whether or not we're the last of the step we're not going to output the same thing
   var files = {};
   files.dest = outfile;
-  files.src = [];
-  context.inFiles.forEach(function(f) { files.src.push(path.join(context.inDir, f));} );
+  files.src = context.inFiles.map(context.resolveInFile, context);
   cfg.files.push(files);
   context.outFiles = [block.dest];
   return cfg;

--- a/lib/config/uglifyjs.js
+++ b/lib/config/uglifyjs.js
@@ -21,13 +21,13 @@ exports.createConfig = function(context, block) {
     var files = {};
     var ofile = path.join(context.outDir, block.dest);
     files.dest = ofile;
-    files.src = context.inFiles.map(function(fname) { return path.join(context.inDir, fname);});
-    // cfg[ofile] = context.inFiles.map(function(fname) { return path.join(context.inDir, fname);});
+    files.src = context.inFiles.map(context.resolveInFile, context);
+    // cfg[ofile] = context.inFiles.map(context.resolveInFile, context);
     cfg.files.push(files);
     context.outFiles.push(block.dest);
   } else {
     context.inFiles.forEach(function(fname) {
-      var file = path.join(context.inDir, fname);
+      var file = context.resolveInFile(fname);
       var outfile = path.join(context.outDir, fname);
       cfg.files.push({src: [file], dest: outfile});
       // cfg[outfile] = [file];

--- a/lib/configwriter.js
+++ b/lib/configwriter.js
@@ -145,12 +145,19 @@ ConfigWriter.prototype.process = function(file, config) {
   }
 
   lfile.blocks.forEach(function(block) {
-    // FIXME: support several searchPath...
-    var context = { inDir: self.root || lfile.searchPath[0], inFiles: block.src, outFiles: []};
+    // NOTE: initial inDir ignores multiple search paths, but it's only used by config/requirejs;
+    //       everything else uses resolveInFile() which (will) check all paths.
+    var inDir = (block.searchPath.length > 0) ? block.searchPath[0] : (self.root || lfile.searchPath[0]),
+        context = {inDir: inDir, inFiles: block.src, outFiles: []};
 
-    if (block.searchPath.length > 0 ) {
-      // FIXME: we must use all the furnished directories
-      context.inDir = block.searchPath[0];
+    function resolveInFile (fname){
+      // FIXME: support block & file searchpaths, root array, app resolver.
+      return path.join(inDir, fname);
+    }
+    context.resolveInFile = resolveInFile;
+
+    function resolveTempFile(fname) {
+      return path.join(context.inDir, fname);
     }
 
     self.forEachStep(block.type, function(writer, last) {
@@ -166,15 +173,14 @@ ConfigWriter.prototype.process = function(file, config) {
       config[writer.name].generated = deepMerge(config[writer.name].generated, writer.createConfig(context, block));
       context.inDir = context.outDir;
       context.inFiles = context.outFiles;
+      context.resolveInFile = resolveTempFile;
       context.outFiles = [];
       context.options = null;
     });
 
-    context.inDir = lfile.searchPath[0];
-    if (block.searchPath.length > 0 ) {
-      context.inDir = block.searchPath[0];
-    }
+    context.inDir = inDir;
     context.inFiles = block.src;
+    context.resolveInFile = resolveInFile;
 
     self.postprocessors.forEach(function(pp) {
       config[pp.name] = config[pp.name] || {};

--- a/lib/configwriter.js
+++ b/lib/configwriter.js
@@ -163,7 +163,7 @@ ConfigWriter.prototype.process = function(file, config) {
         source = self.resolveSource(fname, lfile.dir, lfile.name, block.dest, searchPath);
         if (source) {
           if (!fs.existsSync(source)) {
-            throw new Error(_.template('usemin: resolveSource() returned non-existent path "<%= source %>" for "<%= fname %>".',
+            throw new Error(_.template('usemin: resolveSource() returned non-existent path "<%= source %>" for source "<%= fname %>".',
                                        {source: source, fname: fname}));
           }
           return source;

--- a/lib/configwriter.js
+++ b/lib/configwriter.js
@@ -162,9 +162,9 @@ ConfigWriter.prototype.process = function(file, config) {
       if (self.resolveSource) {
         source = self.resolveSource(fname, lfile.dir, lfile.name, block.dest, searchPath);
         if (source) {
-          if (!fs.exists(source)) {
-            grunt.fatal(_.template('usemin: resolveSource() returned non-existent path "<%= source %>" for "<%= fname %>".',
-                                   {source: source, fname: fname}));
+          if (!fs.existsSync(source)) {
+            throw new Error(_.template('usemin: resolveSource() returned non-existent path "<%= source %>" for "<%= fname %>".',
+                                       {source: source, fname: fname}));
           }
           return source;
         }
@@ -172,12 +172,17 @@ ConfigWriter.prototype.process = function(file, config) {
       if (source !== false) {
         for (var i=0; i<searchPath.length; ++i) {
           source = path.join(searchPath[i], fname);
-          if (fs.exists(source)) { return source; }
+          if (fs.existsSync(source)) { return source; }
         }
       }
       if (self.warnMissing) {
-        grunt.warn(_.template('usemin: can\'t resolve source reference "<%= fname %>" (file "<%= filepath %>", block "<%= block.dest %>").',
-                              {fname: fname, block: block, filepath: path.join(lfile.dir, lfile.name)}));
+        var msg = _.template('usemin: can\'t resolve source reference "<%= fname %>" (file "<%= filepath %>", block "<%= block.dest %>").',
+                             {fname: fname, block: block, filepath: path.join(lfile.dir, lfile.name)});
+        if (grunt.option('force')) {
+          grunt.fail.warn(msg);
+        }else{
+          throw new Error(msg);
+        }
       }
       // we know it's not there, but return placeholder to match old behavior.
       return path.join(searchPath[0], fname);

--- a/lib/configwriter.js
+++ b/lib/configwriter.js
@@ -1,6 +1,7 @@
 'use strict';
 var path = require('path');
 var fs = require('fs');
+var grunt = require('grunt');
 var File = require('./file');
 var _ = require('lodash');
 
@@ -41,13 +42,14 @@ var deepMerge = function(origCfg, cfg) {
 //     - Deliver for each block the requested file under dist directory
 //
 //
-var ConfigWriter = module.exports = function ( flow, dirs ) {
+var ConfigWriter = module.exports = function ( flow, dirs, options ) {
   var self = this;
   this.flow = flow;
   // FIXME: check dest and staging are furnished
   this.root = dirs.root;
   this.dest = dirs.dest;
   this.staging = dirs.staging;
+  this.warnMissing = options && options.warnMissing;
   this.steps = {};
   this.postprocessors = [];
 
@@ -158,6 +160,10 @@ ConfigWriter.prototype.process = function(file, config) {
       for (var i=0; i<searchPath.length; ++i) {
         var source = path.join(searchPath[i], fname);
         if (fs.exists(source)) { return source; }
+      }
+      if (self.warnMissing) {
+        grunt.warn(_.template('usemin can\'t resolve source reference "<%= fname %>" (file "<%= filepath %>", block "<%= block.dest %>").',
+                              {fname: fname, block: block, filepath: path.join(lfile.dir, lfile.name)}));
       }
       // we know it's not there, but return placeholder to match old behavior.
       return path.join(searchPath[0], fname);

--- a/lib/configwriter.js
+++ b/lib/configwriter.js
@@ -50,6 +50,7 @@ var ConfigWriter = module.exports = function ( flow, dirs, options ) {
   this.dest = dirs.dest;
   this.staging = dirs.staging;
   this.warnMissing = options && options.warnMissing;
+  this.resolveSource = options && options.resolveSource;
   this.steps = {};
   this.postprocessors = [];
 
@@ -157,12 +158,25 @@ ConfigWriter.prototype.process = function(file, config) {
     var context = {inDir: searchPath[0], inFiles: block.src, outFiles: []};
 
     function resolveInFile (fname){
-      for (var i=0; i<searchPath.length; ++i) {
-        var source = path.join(searchPath[i], fname);
-        if (fs.exists(source)) { return source; }
+      var source = null;
+      if (self.resolveSource) {
+        source = self.resolveSource(fname, lfile.dir, lfile.name, block.dest, searchPath);
+        if (source) {
+          if (!fs.exists(source)) {
+            grunt.fatal(_.template('usemin: resolveSource() returned non-existent path "<%= source %>" for "<%= fname %>".',
+                                   {source: source, fname: fname}));
+          }
+          return source;
+        }
+      }
+      if (source !== false) {
+        for (var i=0; i<searchPath.length; ++i) {
+          source = path.join(searchPath[i], fname);
+          if (fs.exists(source)) { return source; }
+        }
       }
       if (self.warnMissing) {
-        grunt.warn(_.template('usemin can\'t resolve source reference "<%= fname %>" (file "<%= filepath %>", block "<%= block.dest %>").',
+        grunt.warn(_.template('usemin: can\'t resolve source reference "<%= fname %>" (file "<%= filepath %>", block "<%= block.dest %>").',
                               {fname: fname, block: block, filepath: path.join(lfile.dir, lfile.name)}));
       }
       // we know it's not there, but return placeholder to match old behavior.

--- a/lib/configwriter.js
+++ b/lib/configwriter.js
@@ -1,5 +1,6 @@
 'use strict';
 var path = require('path');
+var fs = require('fs');
 var File = require('./file');
 var _ = require('lodash');
 
@@ -137,6 +138,8 @@ ConfigWriter.prototype.forEachStep = function(blockType, cb) {
 ConfigWriter.prototype.process = function(file, config) {
   var self = this;
   var lfile = file;
+  var rootPath = self.root || [];
+  if (!Array.isArray(rootPath)) { rootPath = [rootPath]; }
 
   config = config || {};
 
@@ -145,14 +148,19 @@ ConfigWriter.prototype.process = function(file, config) {
   }
 
   lfile.blocks.forEach(function(block) {
-    // NOTE: initial inDir ignores multiple search paths, but it's only used by config/requirejs;
-    //       everything else uses resolveInFile() which (will) check all paths.
-    var inDir = (block.searchPath.length > 0) ? block.searchPath[0] : (self.root || lfile.searchPath[0]),
-        context = {inDir: inDir, inFiles: block.src, outFiles: []};
+    // NOTE: initial context.inDir is only used by ./config/requirejs,
+    //       everything else uses context.resolveInFile(),
+    //       which checks entire searchPath.
+    var searchPath = block.searchPath.concat(rootPath, lfile.searchPath);
+    var context = {inDir: searchPath[0], inFiles: block.src, outFiles: []};
 
     function resolveInFile (fname){
-      // FIXME: support block & file searchpaths, root array, app resolver.
-      return path.join(inDir, fname);
+      for (var i=0; i<searchPath.length; ++i) {
+        var source = path.join(searchPath[i], fname);
+        if (fs.exists(source)) { return source; }
+      }
+      // we know it's not there, but return placeholder to match old behavior.
+      return path.join(searchPath[0], fname);
     }
     context.resolveInFile = resolveInFile;
 
@@ -178,7 +186,7 @@ ConfigWriter.prototype.process = function(file, config) {
       context.options = null;
     });
 
-    context.inDir = inDir;
+    context.inDir = searchPath[0];
     context.inFiles = block.src;
     context.resolveInFile = resolveInFile;
 

--- a/tasks/usemin.js
+++ b/tasks/usemin.js
@@ -150,7 +150,7 @@ module.exports = function (grunt) {
 
     var flow = getFlowFromConfig(grunt.config('useminPrepare'), this.target);
 
-    var c = new ConfigWriter( flow, {root: root, dest: dest, staging: staging} );
+    var c = new ConfigWriter( flow, {root: root, dest: dest, staging: staging}, options);
 
     var cfgNames = [];
     c.stepWriters().forEach(function(i) { cfgNames.push(i.name);});

--- a/test/test-config-concat.js
+++ b/test/test-config-concat.js
@@ -25,8 +25,15 @@ describe('Concat config write', function () {
     assert.equal(concatConfig.name, 'concat');
   });
 
+  function resolveInFile(fname) {
+    // jshint -W040
+    return path.join(this.inDir, fname);
+    // FIXME: requires jshint 2.3: // jshint +W040
+  }
+
   it('should use the input files correctly', function () {
-    var ctx = { inDir: '.', inFiles: ['foo.js', 'bar.js', 'baz.js'], outDir: 'tmp/concat', outFiles: []};
+    var ctx = { inDir: '.', inFiles: ['foo.js', 'bar.js', 'baz.js'], outDir: 'tmp/concat', outFiles: [],
+                resolveInFile: resolveInFile };
     var cfg = concatConfig.createConfig( ctx, block );
     assert.ok(cfg.files);
     assert.equal(cfg.files.length, 1);

--- a/test/test-config-uglifyjs.js
+++ b/test/test-config-uglifyjs.js
@@ -25,8 +25,15 @@ describe('Uglifyjs config write', function () {
     assert.equal(uglifyjsConfig.name, 'uglify');
   });
 
+  function resolveInFile(fname) {
+    // jshint -W040
+    return path.join(this.inDir, fname);
+    // FIXME: requires jshint 2.3: // jshint +W040
+  }
+
   it('should use the input files correctly', function () {
-    var ctx = { inDir: 'zzz', inFiles: ['foo.js', 'bar.js', 'baz.js'], outDir: 'tmp/uglifyjs', outFiles: []};
+    var ctx = { inDir: 'zzz', inFiles: ['foo.js', 'bar.js', 'baz.js'], outDir: 'tmp/uglifyjs', outFiles: [],
+                resolveInFile: resolveInFile };
     var cfg = uglifyjsConfig.createConfig( ctx, block );
     assert.ok(cfg.files);
     assert.equal(cfg.files.length, 3);
@@ -44,7 +51,8 @@ describe('Uglifyjs config write', function () {
   });
 
   it('should use the destination file if it is the last step of the pipe.', function () {
-    var ctx = { inDir: 'zzz', inFiles: ['foo.js', 'bar.js', 'baz.js'], outDir: 'dist', outFiles: [], last: true};
+    var ctx = { inDir: 'zzz', inFiles: ['foo.js', 'bar.js', 'baz.js'], outDir: 'dist', outFiles: [], last: true,
+                resolveInFile: resolveInFile };
     var cfg = uglifyjsConfig.createConfig( ctx, block );
     assert.ok(cfg.files);
     assert.equal(cfg.files.length, 1);

--- a/test/test-config-writer.js
+++ b/test/test-config-writer.js
@@ -1,4 +1,6 @@
 'use strict';
+var fs = require('fs');
+var path = require('path');
 var assert = require('assert');
 var helpers = require('./helpers');
 var Flow = require('../lib/flow.js');
@@ -46,6 +48,18 @@ describe('ConfigWriter', function () {
       });
 
       assert.deepEqual(config, expected);
+    });
+
+    it('should detect missing sources when warnMissing=true', function (){
+      var flow = new Flow({'steps': {'js': ['concat', 'uglifyjs']}});
+      var blocks = helpers.blocks();
+      blocks[0].src = ['foo.js'];
+      var file = helpers.createFile('foo', 'warn-missing', blocks);
+      var c = new ConfigWriter( flow, {input: 'warn-missing', dest: 'dist', staging: '.tmp'}, {warnMissing: true});
+      assert.throws(function () { c.process(file) }, /can't resolve source reference "foo.js"/);
+      fs.mkdir('warn-missing');
+      fs.writeFileSync(path.join('warn-missing', 'foo.js'), 'var a=1;');
+      c.process(file);
     });
 
     it('should have a configurable destination directory', function() {


### PR DESCRIPTION
This set of commits make a number of changes to how source urls are resolved,
with the hope of making things more flexible and handling some edge cases.
I tried to change things in a way which should be backwards-compatible
with existing third-party flow plugins, while providing a number of new features:

* the `context` object now exposes a `context.resolveInFile(fname)` helper (provided by the `ConfigWriter`), which flow plugins should use to convert a filename to it's path
  (rather than using `path.join(context.inDir, fname)`). This single change
  allows source resolution to be moved back into ConfigWriter, where a 
  number of new features have been added...

* the `root` option can now be an array, which will be searched in order.
  (this is similar to PR #296, but the changes here are made to lib/configwriter,
  rather than lib/config/concat, and should work for all plugins).

* source urls are now resolved against the entire block searchpath,
  all the root dirs, and then all the file searchpath (this clears up
  a few FIXMEs within the code).

* I've added a `warnMissing` option, which causes ConfigWriter to issue a warning/error
  for any source references it can't resolve (ala issue #260). This defaults to off,
  so as not to break things for people.

* finally, I added a `resolveSource()` option, which allows applications
  to completely override how source urls are resolved... this allows handling of
  applications with complex url rewrite rules, runtime template insertions
  within the source url, or any other border case not covered by the default behavior.

~~I'm still testing this on my own projects, and given that I'm not familiar
with Mocha, don't have any unittests for this features written yet...
but I'm willing to give it a try if there's interest in merging this PR.~~ 
edit: All of these features should now have unittests. 
