### PR TITLE
fix #307 - grunt-watch spawn:false compatibility fix

### DIFF
--- a/lib/configwriter.js
+++ b/lib/configwriter.js
@@ -6,15 +6,20 @@ var _ = require('lodash');
 var deepMerge = function (origCfg, cfg) {
   var outCfg = origCfg;
 
+// If the newly generated part is already in the config file
+// with the same destination update only the source part, instead of add the whole block again.
+// This way the same targets wont be regenerated multiple times if usemin is called
+// multiple times which can happen with grunt-watcher spawn:false mode (#307)
+
   if (origCfg.files && cfg.files) {
     var done = false;
-    for (var i = 0; i < origCfg.files.length; i++){
-      if (outCfg.files[i].dest === cfg.files[0].dest){
+    for (var i = 0; i < origCfg.files.length; i++) {
+      if (outCfg.files[i].dest === cfg.files[0].dest) {
         outCfg.files[i].src = cfg.files[0].src;
         done = true;
       }
     }
-    if (!done){
+    if (!done) {
       outCfg.files = _.union(origCfg.files, cfg.files);
     }
   } else if (cfg.files) {

--- a/lib/configwriter.js
+++ b/lib/configwriter.js
@@ -7,7 +7,16 @@ var deepMerge = function (origCfg, cfg) {
   var outCfg = origCfg;
 
   if (origCfg.files && cfg.files) {
-    outCfg.files = _.union(origCfg.files, cfg.files);
+    var done = false;
+    for( var i = 0; i<origCfg.files.length; i++){
+      if(outCfg.files[i].dest === cfg.files[0].dest){
+        outCfg.files[i].src = cfg.files[0].src;
+        done = true;
+      }
+    }
+    if(!done){
+      outCfg.files = _.union(origCfg.files, cfg.files);
+    }
   } else if (cfg.files) {
     outCfg.files = cfg.files;
   }

--- a/lib/configwriter.js
+++ b/lib/configwriter.js
@@ -8,13 +8,13 @@ var deepMerge = function (origCfg, cfg) {
 
   if (origCfg.files && cfg.files) {
     var done = false;
-    for( var i = 0; i<origCfg.files.length; i++){
-      if(outCfg.files[i].dest === cfg.files[0].dest){
+    for (var i = 0; i < origCfg.files.length; i++){
+      if (outCfg.files[i].dest === cfg.files[0].dest){
         outCfg.files[i].src = cfg.files[0].src;
         done = true;
       }
     }
-    if(!done){
+    if (!done){
       outCfg.files = _.union(origCfg.files, cfg.files);
     }
   } else if (cfg.files) {

--- a/test/test-config-writer.js
+++ b/test/test-config-writer.js
@@ -402,5 +402,24 @@ describe('ConfigWriter', function () {
         assert.deepEqual(names, ['concat', 'uglify']);
       });
     });
+
+    it('should not add the same block multiple times when processed 2 times', function () {
+      var flow = new Flow({ steps: { js: ['concat', 'uglifyjs'] } });
+
+      var file = helpers.createFile('foo', 'app', blocks);
+      var c = new ConfigWriter(flow, { input: 'app', dest: 'destination', staging: '.tmp' });
+      var config = c.process(file);
+      config = c.process(file,config);
+      var expected = helpers.normalize({
+        concat: { generated: { files: [
+          { dest: '.tmp/concat/scripts/site.js', src: ['app/foo.js', 'app/bar.js', 'app/baz.js'] }
+        ] } },
+        uglify: { generated: { files: [
+          { dest: 'destination/scripts/site.js', src: ['.tmp/concat/scripts/site.js'] }
+        ] } }
+      });
+
+      assert.deepEqual(config, expected);
+    });
   });
 });

--- a/test/test-config-writer.js
+++ b/test/test-config-writer.js
@@ -403,20 +403,20 @@ describe('ConfigWriter', function () {
       });
     });
 
-    it('should not add the same block multiple times when processed 2 times', function () {
-      var flow = new Flow({ steps: { js: ['concat', 'uglifyjs'] } });
+    it('should not add the same block multiple times though we call process() explicitly 2 times.', function () {
+      var flow = new Flow({steps: {js: ['concat', 'uglifyjs']}});
 
       var file = helpers.createFile('foo', 'app', blocks);
-      var c = new ConfigWriter(flow, { input: 'app', dest: 'destination', staging: '.tmp' });
+      var c = new ConfigWriter(flow, {input: 'app', dest: 'destination', staging: '.tmp'});
       var config = c.process(file);
-      config = c.process(file,config);
+      config = c.process(file, config);  // This second process is intentional. Details are in issue #307.
       var expected = helpers.normalize({
-        concat: { generated: { files: [
-          { dest: '.tmp/concat/scripts/site.js', src: ['app/foo.js', 'app/bar.js', 'app/baz.js'] }
-        ] } },
-        uglify: { generated: { files: [
-          { dest: 'destination/scripts/site.js', src: ['.tmp/concat/scripts/site.js'] }
-        ] } }
+        concat: {generated: {files: [
+          {dest: '.tmp/concat/scripts/site.js', src: ['app/foo.js', 'app/bar.js', 'app/baz.js']}
+        ]}},
+        uglify: {generated: {files: [
+          {dest: 'destination/scripts/site.js', src: ['.tmp/concat/scripts/site.js']}
+        ]}}
       });
 
       assert.deepEqual(config, expected);


### PR DESCRIPTION
if the newly generated part is already in the config file with the same destination update only the source part, instead of add the whole block again. This way the same targets won't be regenerated multiple times if usemin is called multiple times which can happen with grunt-watcher spawn:false mode.