### PR TITLE
Eliminate duplicated src-dest file mappings in task configurations due to multiple html files

### DIFF
--- a/lib/configwriter.js
+++ b/lib/configwriter.js
@@ -7,7 +7,34 @@ var deepMerge = function(origCfg, cfg) {
   var outCfg = origCfg;
 
   if (origCfg.files && cfg.files) {
-    outCfg.files = _.union(origCfg.files, cfg.files);
+    // outCfg.files = _.union(origCfg.files, cfg.files);
+    // Eliminate duplicated or conflicted file mappings
+    var origFiles = origCfg.files.slice();
+    _.each(cfg.files, function(fm) {
+      // Loop for file mappings of new configuration
+      var matchFm = _.find(origFiles, function(origFm) {
+        // Loop for file mappings of original configuration
+        if (fm.dest === origFm.dest) {
+          // A match is found: same destination for two file mappings
+          if (!_.isEqual(fm, origFm)) {
+            // Conflict destination with different sources. Throw an error
+            var util = require('util');
+            var inspect = function (obj) {
+              return util.inspect(obj, false, 4, true);
+            };
+            throw new Error('Conflict destination with different sources:\n  ' + inspect(origFm) + '\n  ' + inspect(fm));
+          }
+          // Stop looping when a match is found
+          return true;
+        }
+      });
+      // End of loop for file mappings of original configuration
+      if (_.isUndefined(matchFm)) {
+        // No match. A new file mapping should be added
+        outCfg.files.push(fm);
+      }
+    });
+    // End of loop for file mappings of new configuration
   } else if (cfg.files) {
     outCfg.files = cfg.files;
   }


### PR DESCRIPTION
Try to fix #289. This helps multi-page development by reducing redundant resource compilation.
