### PR TITLE
Fix for: Image attributes that end in "src" but are prefixed will cause ...

### DIFF
--- a/lib/fileprocessor.js
+++ b/lib/fileprocessor.js
@@ -12,7 +12,7 @@ var _defaultPatterns = {
       [ /<link[^\>]+href=['"]([^"']+)["']/gm,
       'Update the HTML with the new css filenames'
       ],
-      [ /<img[^\>]+src=['"]([^"']+)["']/gm,
+      [ /<img[^\>]* src=['"]([^"']+)["']/gm,
       'Update the HTML with the new img filenames'
       ],
       [ /data-main\s*=['"]([^"']+)['"]/gm,

--- a/test/test-fileprocessor.js
+++ b/test/test-fileprocessor.js
@@ -319,6 +319,12 @@ describe('FileProcessor', function() {
       assert.equal(replaced, '<img src="' + filemapping['app/image.png'] + '">');
     });
 
+    it('should replace img reference with revved version', function () {
+      var content = '<img src="image.png" ng-src="{{something}}">';
+      var replaced = fp.replaceWithRevved(content, ['app']);
+      assert.equal(replaced, '<img src="' + filemapping['app/image.png'] + '" ng-src="{{something}}">');
+    });
+
     it('should replace data reference with revved version', function () {
       var content = '<li data-lang="fr" data-src="image.png"></li>';
       var replaced = fp.replaceWithRevved(content, ['app']);


### PR DESCRIPTION
...the actual src attr to be skipped if it appears after the src attribute.
