### PR TITLE
Fix <img src> not being replaced when followed by ng-src

### DIFF
--- a/lib/fileprocessor.js
+++ b/lib/fileprocessor.js
@@ -11,7 +11,7 @@ var _defaultPatterns = {
     [ /<link[^\>]+href=['"]([^"']+)["']/gm,
     'Update the HTML with the new css filenames'
     ],
-    [ /<img[^\>]+src=['"]([^"']+)["']/gm,
+    [ /<img[^\>\S]+src=['"]([^"']+)["']/gm,
     'Update the HTML with the new img filenames'
     ],
     [ /<video[^\>]+src=['"]([^"']+)["']/gm,

--- a/test/test-fileprocessor.js
+++ b/test/test-fileprocessor.js
@@ -320,6 +320,12 @@ describe('FileProcessor', function() {
       assert.equal(replaced, '<img src="' + filemapping['app/image.png'] + '">');
     });
 
+    it('should replace img src regardless of ng-src attribute', function() {
+      var content = '<img src="image.png" ng-src="{{my.image}}">';
+      var replaced = fp.replaceWithRevved(content, ['app']);
+      assert.equal(replaced, '<img src="' + filemapping['app/image.png'] + '" ng-src="{{my.image}}">');
+    });
+
     it('should replace video reference with revved version', function () {
       var content = '<video src="video.webm">';
       var replaced = fp.replaceWithRevved(content, ['app']);


### PR DESCRIPTION
When an `<img src>` attribute is followed by an `ng-src` attribute (used by Angular), the `ng-src` attribute will be processed instead of the `src` attribute.

This ensures that only the `src` attribute is processed, the `ng-src` attribute is ignored.
