### PR TITLE
test/helpers.js: fix check for array.

### DIFF
--- a/test/helpers.js
+++ b/test/helpers.js
@@ -96,7 +96,7 @@ helpers.makeFinder = function(mapping) {
         var dir = _.find(b, function(d) {return mapping[path.join(d,s).replace(/\\/g, '/')]; });
         var file = typeof dir !== 'undefined' ? mapping[path.join(dir,s).replace(/\\/g, '/')] : s;
 
-        if (typeof file === 'array' || file instanceof Array) {
+        if (Array.isArray(file)) {
           output = file[0];
         } else {
           output = file;


### PR DESCRIPTION
Another approach would be to use lodash's `isArray`. I went with `Array.isArray` since it's used one more time in the codebase, but I can change it if people prefer the lodash approach.
