### PR TITLE
Fix <img src> when src preceded by other attribute

### DIFF
--- a/lib/fileprocessor.js
+++ b/lib/fileprocessor.js
@@ -11,7 +11,7 @@ var _defaultPatterns = {
     [ /<link[^\>]+href=['"]([^"']+)["']/gm,
     'Update the HTML with the new css filenames'
     ],
-    [ /<img[^\>\S]+src=['"]([^"']+)["']/gm,
+    [ /<img[^\>]*[^\>\S]+src=['"]([^"']+)["']/gm,
     'Update the HTML with the new img filenames'
     ],
     [ /<video[^\>]+src=['"]([^"']+)["']/gm,

--- a/test/test-fileprocessor.js
+++ b/test/test-fileprocessor.js
@@ -326,6 +326,12 @@ describe('FileProcessor', function() {
       assert.equal(replaced, '<img src="' + filemapping['app/image.png'] + '" ng-src="{{my.image}}">');
     });
 
+    it('should replace img src after class attribute', function() {
+      var content = '<img class="myclass" src="image.png">';
+      var replaced = fp.replaceWithRevved(content, ['app']);
+      assert.equal(replaced, '<img class="myclass" src="' + filemapping['app/image.png'] + '">');
+    });
+
     it('should replace video reference with revved version', function () {
       var content = '<video src="video.webm">';
       var replaced = fp.replaceWithRevved(content, ['app']);


### PR DESCRIPTION
Fixes regression introduced in commit 0934764 (Issue #353).
