### PR TITLE
Makes quotes optional for inlined background url

### DIFF
--- a/lib/fileprocessor.js
+++ b/lib/fileprocessor.js
@@ -44,7 +44,7 @@ var _defaultPatterns = {
       'Update the HTML with data-* tags'
     ],
     [
-      /url\(\s*['"]([^"']+)["']\s*\)/gm,
+      /url\(\s*['"]?([^"'\)]+)["']?\s*\)/gm,
       'Update the HTML with background imgs, case there is some inline style'
     ],
     [

--- a/test/test-fileprocessor.js
+++ b/test/test-fileprocessor.js
@@ -366,6 +366,12 @@ describe('FileProcessor', function () {
       assert.equal(replaced, '<li style="background: url("' + filemapping['app/image.png'] + '");"></li>');
     });
 
+    it('should replace unquoted image reference in inlined style', function () {
+      var content = '<li style="background: url(image.png);"></li>';
+      var replaced = fp.replaceWithRevved(content, ['app']);
+      assert.equal(replaced, '<li style="background: url(' + filemapping['app/image.png'] + ');"></li>');
+    });
+
     it('should replace image reference in anchors', function () {
       var content = '<a href="image.png"></a>';
       var replaced = fp.replaceWithRevved(content, ['app']);


### PR DESCRIPTION
This is the same as the regex used for css.
