### PR TITLE
Document "ignored" blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Blocks are expressed as:
 ```
 
 * **type**: either `js` or `css`
+ * If another type, the block will be ignored.  Useful for "development only" blocks that won't appear in your build
 * **alternate search path**: (optional) By default the input files are relative to the treated file. Alternate search path allows one to change that
 * **path**: the file path of the optimized file, the target output
 


### PR DESCRIPTION
If using a block type other than `js` or `css` the block will be "ignored" and replaced by an empty string.  This behaviour is enabled by fixes in #303 and I believe it should be documented because it is incredibly useful for including development-only scripts that you don't want to include in your production build, e.g. Angular's mock http service and a script that you use to configure it.
