### PR TITLE
Adding support for prefetch link

### DIFF
--- a/lib/fileprocessor.js
+++ b/lib/fileprocessor.js
@@ -116,6 +116,8 @@ FileProcessor.prototype.replaceWith = function replaceWith(block) {
   } else if (block.type === 'css') {
     var media = block.media ? ' media="' + block.media + '"' : '';
     result = block.indent + conditionalStart + '<link rel="stylesheet" href="' + dest + '"' + media + '/>' + conditionalEnd;
+  } else if (block.type === 'prefetch') {
+    result = block.indent + conditionalStart + '<link rel="prefetch" href="' + dest + '"/>' + conditionalEnd;
   } else if (block.defer) {
     result = block.indent + conditionalStart + '<script defer src="' + dest + '"><\/script>' + conditionalEnd;
   } else if (block.async) {


### PR DESCRIPTION
Currently grunt-usemin doesn't update tags like the following:

```
<link rel="prefetch" src="resourcetoprefetch">
```

This PR adds support for this by enabling the type prefetch. This is useful if you are generating an asset (for example a CSS sprite) that is going to be used later and it is going to have a random generated filename and you want to download it before it is required.
