### PR TITLE
Skip duplicate configurations.

### DIFF
--- a/lib/configwriter.js
+++ b/lib/configwriter.js
@@ -49,6 +49,7 @@ var ConfigWriter = module.exports = function (flow, dirs) {
   this.staging = dirs.staging;
   this.steps = {};
   this.postprocessors = [];
+  this.destinations = {};
 
   // We need to create all the needed config writers, given them their output directory
   // E.g, if we do have the flow concat | uglifyjs, the output dir will be .tmp/concat and dist
@@ -158,6 +159,9 @@ ConfigWriter.prototype.process = function (file, config) {
     }
 
     self.forEachStep(block.type, function (writer, last) {
+      var blockConfig;
+      var fileSet;
+      var dest;
 
       // If this is the last writer of the pipe, we need to output
       // in the destination directory
@@ -167,7 +171,26 @@ ConfigWriter.prototype.process = function (file, config) {
       config[writer.name].generated = config[writer.name].generated || {};
       context.options = config[writer.name];
       // config[writer.name].generated = _.extend(config[writer.name].generated, writer.createConfig(context, block));
-      config[writer.name].generated = deepMerge(config[writer.name].generated, writer.createConfig(context, block));
+      blockConfig = writer.createConfig(context, block);
+      if (blockConfig.files) {
+        fileSet = blockConfig.files;
+        blockConfig.files = [];
+        fileSet.forEach(function (filesInfo) {
+          dest = filesInfo.dest;
+          if (!self.destinations[dest]) {
+            self.destinations[dest] = filesInfo;
+            blockConfig.files.push(filesInfo);
+          } else if (!_.isEqual(self.destinations[dest], filesInfo)) {
+            throw new Error('Different sources attempting to write to the same destination:\n ' + JSON.stringify(self.destinations[dest], null, '    ') + '\n  ' + JSON.stringify(blockConfig, null, '    '));
+          }
+        });
+
+        if (blockConfig.files.length) {
+          config[writer.name].generated = deepMerge(config[writer.name].generated, blockConfig);
+        }
+      } else {
+        config[writer.name].generated = deepMerge(config[writer.name].generated, blockConfig);
+      }
       context.inDir = context.outDir;
       context.inFiles = context.outFiles;
       context.outFiles = [];


### PR DESCRIPTION
This should resolve #289.

This also detects a bad configuration where multiple blocks attempt to write
to the same destination with different sources.

I realize #324 is already a PR for this, but the method taken in that PR is O(n^2) and this avoids that extra looping. This PR also has tests.
