### PR TITLE
processes image content in XML files. No tests.

### DIFF
--- a/lib/fileprocessor.js
+++ b/lib/fileprocessor.js
@@ -58,6 +58,10 @@ var _defaultPatterns = {
     [
       /<meta[^\>]+content=['"]([^"']+)["']/gm,
       'Update the HTML with the new img filenames in meta tags'
+    ],
+    [
+      /<content\stype="image[^\>]*[^\>\S]+src=['"]http:\/{2}[^\/]*\/([^"']+)["']/gm,
+      'Update the XML image content with the new img filenames'
     ]
   ],
   css: [


### PR DESCRIPTION
If you generate atom or RSS feeds then you need to link to the image files with the revised filenames. It also requires a match on absolute paths. Wasn't sure how to create a test for it or run it.

Also had to change the usemin config in Gruntfile.js
html: ['<%= config.dist %>/{,*_/}_.{html,xml}'],
Hopefully it will be useful to someone else.
