### PR TITLE
Giving access of config generated to postprocessor.

### DIFF
--- a/lib/configwriter.js
+++ b/lib/configwriter.js
@@ -207,7 +207,7 @@ ConfigWriter.prototype.process = function (file, config) {
       self.postprocessors[block.type].forEach(function (pp) {
         config[pp.name] = config[pp.name] || {};
         context.options = config[pp.name];
-        config[pp.name] = _.extend(config[pp.name], pp.createConfig(context, block));
+        config[pp.name] = _.extend(config[pp.name], pp.createConfig(context, block, config[pp.name]));
         context.options = null;
       });
     }


### PR DESCRIPTION
I think its good idea to have post processors able to read the config object generated by usemin. Will be helpful in case postprocessors need to change only small part of the config generated. Otherwise postprocessors have to recreate the object completely causing duplication of code.