### PR TITLE
Ignore query params when replacing URLs of revved assets

### DIFF
--- a/lib/fileprocessor.js
+++ b/lib/fileprocessor.js
@@ -6,31 +6,31 @@ var _ = require('lodash');
 var _defaultPatterns = {
   html: [
     [
-      /<script.+src=['"]([^"']+)["']/gm,
+      /<script.+src=['"]([^"'\?]+(\?[^"']*)?)["']/gm,
       'Update the HTML to reference our concat/min/revved script files'
     ],
     [
-      /<link[^\>]+href=['"]([^"']+)["']/gm,
+      /<link[^\>]+href=['"]([^"'\?]+)(\?[^"']*)?["']/gm,
       'Update the HTML with the new css filenames'
     ],
     [
-      /<img[^\>]*[^\>\S]+src=['"]([^"']+)["']/gm,
+      /<img[^\>]*[^\>\S]+src=['"]([^"'\?]+)(\?[^"']*)?["']/gm,
       'Update the HTML with the new img filenames'
     ],
     [
-      /<video[^\>]+src=['"]([^"']+)["']/gm,
+      /<video[^\>]+src=['"]([^"'\?]+)(\?[^"']*)?["']/gm,
       'Update the HTML with the new video filenames'
     ],
     [
-      /<video[^\>]+poster=['"]([^"']+)["']/gm,
+      /<video[^\>]+poster=['"]([^"'\?]+)(\?[^"']*)?["']/gm,
       'Update the HTML with the new poster filenames'
     ],
     [
-      /<source[^\>]+src=['"]([^"']+)["']/gm,
+      /<source[^\>]+src=['"]([^"'\?]+)(\?[^"']*)?["']/gm,
       'Update the HTML with the new source filenames'
     ],
     [
-      /data-main\s*=['"]([^"']+)['"]/gm,
+      /data-main\s*=['"]([^"'\?]+)(\?[^"']*)?['"]/gm,
       'Update the HTML with data-main tags',
       function (m) {
         return m.match(/\.js$/) ? m : m + '.js';
@@ -40,23 +40,23 @@ var _defaultPatterns = {
       }
     ],
     [
-      /data-(?!main).[^=]+=['"]([^'"]+)['"]/gm,
+      /data-(?!main).[^=]+=['"]([^'"\?]+)(\?[^"']*)?['"]/gm,
       'Update the HTML with data-* tags'
     ],
     [
-      /url\(\s*['"]?([^"'\)]+)["']?\s*\)/gm,
+      /url\(\s*['"]?([^"'\)\?]+)(\?[^"'\)]*)?["']?\s*\)/gm,
       'Update the HTML with background imgs, case there is some inline style'
     ],
     [
-      /<a[^\>]+href=['"]([^"']+)["']/gm,
+      /<a[^\>]+href=['"]([^"'\?]+)(\?[^"']*)?["']/gm,
       'Update the HTML with anchors images'
     ],
     [
-      /<input[^\>]+src=['"]([^"']+)["']/gm,
+      /<input[^\>]+src=['"]([^"'\?]+)(\?[^"']*)?["']/gm,
       'Update the HTML with reference in input'
     ],
     [
-      /<meta[^\>]+content=['"]([^"']+)["']/gm,
+      /<meta[^\>]+content=['"]([^"'\?]+)(\?[^"']*)?["']/gm,
       'Update the HTML with the new img filenames in meta tags'
     ]
   ],

--- a/test/test-fileprocessor.js
+++ b/test/test-fileprocessor.js
@@ -408,6 +408,12 @@ describe('FileProcessor', function () {
       assert.equal(replaced, '<meta name="foo" content="' + filemapping['app/image.png'] + '">');
     });
 
+    it('should replace references with no regard to query parameters', function () {
+      var content = '<img src="image.png?query=foo">';
+      var replaced = fp.replaceWithRevved(content, ['app']);
+      assert.equal(replaced, '<img src="' + filemapping['app/image.png'] + '?query=foo">');
+    });
+
   });
 
   describe('css type', function () {
@@ -456,6 +462,16 @@ describe('FileProcessor', function () {
 
       });
 
+      it('should ignore query parameters', function () {
+        var contentQueryParams = '.myclass {\nbackground: url("/images/test.png") no-repeat center center;\nbackground: url("/images/misc/test.png?questionmark=?") no-repeat center center;\nbackground: url("//images/foo.png?foo=bar") no-repeat center center;\nfilter: progid:DXImageTransform.Microsoft.AlphaImageLoader(src="images/pic.png?foo=bar&bar=foo",sizingMethod="scale");}';
+        var changed = cp.replaceWithRevved(contentQueryParams, ['foo']);
+
+        assert.ok(changed.match(/\/images\/pic\.23012\.png\?foo=bar&bar=foo/));
+        assert.ok(changed.match(/\/images\/misc\/test\.23012\.png\?questionmark=\?/));
+        assert.ok(changed.match(/\/\/images\/foo\.23012\.png\?foo=bar/));
+
+      });
+
     });
 
     describe('relative path', function () {
@@ -489,6 +505,15 @@ describe('FileProcessor', function () {
         assert.ok(changed.match(/\"\.\.\/images\/misc\/test\.23012\.png/));
         assert.ok(changed.match(/\"images\/foo\.23012\.png/));
 
+      });
+
+      it('should ignore query parameters in urls', function () {
+        var contentQueryParams = '.myclass {\nbackground: url("images/test.png?questionmark=?") no-repeat center center;\nbackground: url("../images/misc/test.png?foo=bar") no-repeat center center;\nbackground: url("images/foo.png?version=1.3.0") no-repeat center center;}';
+        var changed = cp.replaceWithRevved(contentQueryParams, ['build']);
+
+        assert.ok(changed.match(/\"images\/test\.23012\.png\?questionmark=\?/));
+        assert.ok(changed.match(/\"\.\.\/images\/misc\/test\.23012\.png\?foo=bar/));
+        assert.ok(changed.match(/\"images\/foo\.23012\.png\?version=1.3.0/));
       });
     });
 
@@ -540,6 +565,14 @@ describe('FileProcessor', function () {
         assert.ok(changed.match(/\/styles\/fonts\/icons\.12345\.woff/));
         assert.ok(changed.match(/\/styles\/fonts\/icons\.12345\.ttf/));
         assert.ok(changed.match(/\/styles\/fonts\/icons\.12345\.svg/));
+      });
+
+      it('should ignore query parameters', function () {
+        var contentQueryParams = '@font-face {\nfont-family:"icons";\nsrc:url("/styles/fonts/icons.eot?font=cool");\nsrc:url("/styles/fonts/icons.eot#fragment") format("embedded-opentype"),\nurl("/styles/fonts/icons.woff?query=true") format("woff"),\nurl("/styles/fonts/icons.ttf") format("truetype"),\nurl("/styles/fonts/icons.svg#icons") format("svg");\nfont-weight:normal;\nfont-style:normal;\n}';
+        var changed = cp.replaceWithRevved(contentQueryParams, ['build']);
+
+        assert.ok(changed.match(/\/styles\/fonts\/icons\.12345\.eot\?font=cool/));
+        assert.ok(changed.match(/\/styles\/fonts\/icons\.12345\.woff\?query=true/));
       });
 
     });


### PR DESCRIPTION
This commit enables usemin to match a CSS reference like

  src: url('fonts/myfont.woff?v=1.2.3')

against a file named 'fonts/a4ef223c.myfont.woff' and updates
the reference to

  src: url('fonts/e4ef223c.myfont.woff?v=1.2.3')

Same for query parameters in HTML tags.

Just signed the CLA.
