### PR TITLE
Update revvedfinder.js

### DIFF
--- a/lib/revvedfinder.js
+++ b/lib/revvedfinder.js
@@ -25,7 +25,7 @@ var regexpQuote = function (str) {
 
 RevvedFinder.prototype.getCandidatesFromMapping = function (file, searchPaths) {
   var dirname = path.dirname(file);
-  var filepath = dirname === "." ? "" : dirname + '/';
+  var filepath = dirname === '.' ? '' : dirname + '/';
   var candidates = [];
   var self = this;
 


### PR DESCRIPTION
When file is in the same directory as search path (".") it produces path "./file.txt" instead of "file.txt"
