### PR TITLE
fix FileProcessor.prototype.replaceBlocks bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-node_modules/*
+node_modules
 test/temp
 
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-node_modules
+node_modules/*
 test/temp
 
 

--- a/lib/fileprocessor.js
+++ b/lib/fileprocessor.js
@@ -140,9 +140,9 @@ FileProcessor.prototype.replaceBlocks = function replaceBlocks(file) {
   file.blocks.forEach(function (block) {
     var blockLine = block.raw.join(linefeed);
     var replacement = this.replaceWith(block);
-    replacement = replacement.replace('$', '@#USD#@');
+    replacement = replacement.replace(/\$/g, '@#USD#@');
     result = result.replace(blockLine, replacement);
-    result = result.replace('@#USD#@', '$');
+    result = result.replace(/@#USD#@/g, '$');
   }, this);
   return result;
 };

--- a/lib/fileprocessor.js
+++ b/lib/fileprocessor.js
@@ -139,7 +139,10 @@ FileProcessor.prototype.replaceBlocks = function replaceBlocks(file) {
   var linefeed = /\r\n/g.test(result) ? '\r\n' : '\n';
   file.blocks.forEach(function (block) {
     var blockLine = block.raw.join(linefeed);
-    result = result.replace(blockLine, this.replaceWith(block));
+    var replacement = this.replaceWith(block);
+    replacement = replacement.replace('$', '@#USD#@');
+    result = result.replace(blockLine, replacement);
+    result = result.replace('@#USD#@', '$');
   }, this);
   return result;
 };

--- a/test/test-fileprocessor.js
+++ b/test/test-fileprocessor.js
@@ -57,7 +57,7 @@ describe('FileProcessor', function () {
     it('should replace block with the replacement contains$&(special character)', function () {
       var fp = new FileProcessor('html', {});
       fp.replaceWith = function () {
-        return 'foo$&foo';
+        return 'foo$&foo$&foo';
       };
       var file = {
         content: 'foo\nbar\nbaz\n',
@@ -66,7 +66,7 @@ describe('FileProcessor', function () {
         }]
       };
       var result = fp.replaceBlocks(file);
-      assert.equal(result, 'foo\nfoo$&foo\n');
+      assert.equal(result, 'foo\nfoo$&foo$&foo\n');
     });
   });
 

--- a/test/test-fileprocessor.js
+++ b/test/test-fileprocessor.js
@@ -53,6 +53,21 @@ describe('FileProcessor', function () {
       var result = fp.replaceBlocks(file);
       assert.equal(result, 'foo\nfoo\n');
     });
+
+    it('should replace block with the replacement contains$&(special character)', function () {
+      var fp = new FileProcessor('html', {});
+      fp.replaceWith = function () {
+        return 'foo$&foo';
+      };
+      var file = {
+        content: 'foo\nbar\nbaz\n',
+        blocks: [{
+          raw: ['bar', 'baz']
+        }]
+      };
+      var result = fp.replaceBlocks(file);
+      assert.equal(result, 'foo\nfoo$&foo\n');
+    });
   });
 
   describe('replaceWith', function () {


### PR DESCRIPTION
In FileProcessor.prototype.replaceBlocks,the replacement contains$&(special character),String.replace isn't work.