### PR TITLE
Update README.md correcting post-processor name

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ useminPrepare: {
       },
       post: {
         js: [{
-          name: 'uglifyjs',
+          name: 'uglify',
           createConfig: function (context, block) {
             var generated = context.options.generated;
             generated.options = {


### PR DESCRIPTION
The REAME.md states that to configure the uglify part, one needs to define a 'js' post-processor with name 'uglifyjs'.
It took me a while to understand that I could not get it working because the post-processor name is 'uglify' (without js) 
as can be seen under lib/config/uglifyjs.js : exports.name = 'uglify';
