### PR TITLE
do not replace "/" with "/.DS_Store"

### DIFF
--- a/lib/fileprocessor.js
+++ b/lib/fileprocessor.js
@@ -189,7 +189,7 @@ FileProcessor.prototype.replaceWithRevved = function replaceWithRevved(lines, as
 
       var file = self.finder.find(srcFile, assetSearchPath);
 
-      debug('Found file \'%s\'' + file);
+      debug('Found file \'%s\'', file);
 
       if (src === '/') {
         return match;


### PR DESCRIPTION
when running usemin, url references to "/" were being replaced with "./DS_Store". this PR checks if the src equals "/" and returns the original reference rather than updating.
