### PR TITLE
only output modifications on verbose mode

### DIFF
--- a/tasks/usemin.js
+++ b/tasks/usemin.js
@@ -129,7 +129,7 @@ module.exports = function (grunt) {
     var locator = getLocator(grunt, options);
     var revvedfinder = new RevvedFinder(locator);
     var handler = new FileProcessor(patterns, revvedfinder, function (msg) {
-      grunt.log.writeln(msg);
+      grunt.verbose.writeln(msg);
     }, blockReplacements);
 
     this.files.forEach(function (fileObj) {


### PR DESCRIPTION
We have a large set of modified files and the generated output is overwhelming. I propose to only output so much info on verbose mode.
