### PR TITLE
Fix ability to add custom patterns

### DIFF
--- a/lib/fileprocessor.js
+++ b/lib/fileprocessor.js
@@ -112,8 +112,7 @@ var FileProcessor = module.exports = function (patterns, finder, logcb, blockRep
     }
     this.patterns = _defaultPatterns[patterns];
   } else {
-    // FIXME: check the pattern format
-    this.patterns = patterns;
+    this.patterns = _.merge({}, _defaultPatterns, patterns);
   }
 
   this.log = logcb || function () {};
@@ -174,7 +173,13 @@ FileProcessor.prototype.replaceWithRevved = function replaceWithRevved(lines, as
   };
 
   // Replace reference to script with the actual name of the revved script
-  regexps.forEach(function (rxl) {
+  for (var regexp in regexps) {
+    if (regexps.hasOwnProperty(regexp)) {
+      regexps[regexp].forEach(replace);
+    }
+  }
+
+  function replace(rxl) {
     var filterIn = rxl[2] || identity;
     var filterOut = rxl[3] || identity;
 
@@ -197,12 +202,10 @@ FileProcessor.prototype.replaceWithRevved = function replaceWithRevved(lines, as
       }
       return res;
     });
-  });
+  }
 
   return content;
 };
-
-
 
 FileProcessor.prototype.process = function (filename, assetSearchPath) {
   debug('processing file %s', filename, assetSearchPath);

--- a/tasks/usemin.js
+++ b/tasks/usemin.js
@@ -114,15 +114,14 @@ module.exports = function (grunt) {
     var blockReplacements = options.blockReplacements || {};
 
     debug('Looking at %s target', this.target);
-    var patterns;
+    var patterns = {};
 
     // Check if we have a user defined pattern
     if (options.patterns && options.patterns[this.target]) {
       debug('Using user defined pattern for %s', this.target);
-      patterns = options.patterns[this.target];
+      patterns[this.target] = options.patterns[this.target];
     } else {
       debug('Using predefined pattern for %s', this.target);
-      patterns = options.type;
     }
 
     // var locator = options.revmap ? grunt.file.readJSON(options.revmap) : function (p) { return grunt.file.expand({filter: 'isFile'}, p); };
@@ -146,6 +145,7 @@ module.exports = function (grunt) {
 
         // write the new content to disk
         grunt.file.write(filename, content);
+
       });
     });
   });


### PR DESCRIPTION
Adding patterns completely replaces the patterns in fileprocessor, where it could be more useful if the pattern is appended instead.

``` js
usemin: {
  html: [],
  css: [],
  options: {
    assetsDirs: [],
    patterns: {
      html: [
        [/<img[^\>]*[^\>\S]+ng-src=['"]([^"']+)["']/gm, 'Update the ng-src to reference our revved images']
      ]
    }
  }
}
```
