### PR TITLE
Use chalk to colorize CLI output.

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "test": "grunt test"
   },
   "dependencies": {
+    "chalk": "~0.5.1",
     "debug": "~2.1.0",
     "lodash": "~2.4.1"
   },

--- a/tasks/usemin.js
+++ b/tasks/usemin.js
@@ -1,5 +1,6 @@
 'use strict';
 var util = require('util');
+var chalk = require('chalk');
 
 var inspect = function (obj) {
   return util.inspect(obj, false, 4, true);
@@ -139,7 +140,7 @@ module.exports = function (grunt) {
       files.forEach(function (filename) {
         debug('looking at file %s', filename);
 
-        grunt.log.subhead('Processing as ' + options.type.toUpperCase() + ' - ' + filename);
+        grunt.log.writeln(chalk.bold('Processing as ' + options.type.toUpperCase() + ' - ') + chalk.cyan(filename));
 
         // Our revved version locator
         var content = handler.process(filename, options.assetsDirs);


### PR DESCRIPTION
Fixes #462.

/CC @sindresorhus 

BTW, I went with `writeln` to get rid of the newline when `verbose` isn't used. Feel free to suggest a better solution. Also, feel free to make use of chalk in more places later :)
