### PR TITLE
fix(verbosity): add some ouput for useminPrepare in non verbose mode

### DIFF
--- a/tasks/usemin.js
+++ b/tasks/usemin.js
@@ -205,5 +205,8 @@ module.exports = function (grunt) {
       grunt.verbose.subhead('  ' + name + ':')
         .writeln('  ' + util.inspect(grunt.config(name), false, 4, true, true));
     });
+
+    // only displayed if not in verbose mode
+    grunt.verbose.or.writeln('Configuration changed for', grunt.log.wordlist(cfgNames));
   });
 };


### PR DESCRIPTION
Follow the request from @XhmikosR in #476 in comment:
https://github.com/yeoman/grunt-usemin/issues/476\#issuecomment-61568464

With this last PR I think it should be ok. Only one line displaying information for the user to verify that nothing failed, and if `verbosity` flag set the huge log output as we already know.

/CC @XhmikosR, @sindresorhus 
