### PR TITLE
fix(log): use grunt.log.wordlist

### DIFF
--- a/tasks/usemin.js
+++ b/tasks/usemin.js
@@ -161,7 +161,7 @@ module.exports = function (grunt) {
     var root = options.root;
 
     grunt.verbose
-      .writeln('Going through ' + grunt.verbose.wordlist(this.filesSrc) + ' to update the config')
+      .writeln('Going through ' + grunt.log.wordlist(this.filesSrc) + ' to update the config')
       .writeln('Looking for build script HTML comment blocks');
 
     var flow = getFlowFromConfig(grunt.config('useminPrepare'), this.target);


### PR DESCRIPTION
Fix issue reported on #467 about non existing `grunt.verbose.wordlist`.

See comment https://github.com/yeoman/grunt-usemin/pull/467#issuecomment-62715326
