### PR TITLE
Duplicate blocks should raise a warn instead of a fatal error

### DIFF
--- a/tasks/usemin.js
+++ b/tasks/usemin.js
@@ -187,7 +187,7 @@ module.exports = function (grunt) {
       try {
         config = c.process(filepath, grunt.config());
       } catch (e) {
-        grunt.fail.fatal(e);
+        grunt.fail.warn(e);
       }
 
       _.forEach(cfgNames, function (name) {


### PR DESCRIPTION
Not long ago we got a [merged PR](https://github.com/yeoman/grunt-usemin/pull/382) that avoid duplicated config blocks. That piece is working really well, the problem is just that inside the **useminPrepare** task we are invoking a `grunt.fail.fatal` error that just kills the plugin for everyone that happens to have a duplicated block somewhere. :disappointed: 

As you can see [in the discussion that follows on that same PR](https://github.com/yeoman/grunt-usemin/pull/382#issuecomment-61409135) we have an increased number of feedback from people that have duplicated blocks around their apps and can't use the plugin anymore or are just hacking around the functionality.

My humble suggestion is to change **grunt.fail.fatal** error into a **grunt.fail.warn** so that people wanting to `--force` that kind of behaviour will be allowed to do so.

Thanks!
