### PR TITLE
Fixed tests on Windows. There was a problem with backslashes in path nam...

### DIFF
--- a/test/test-usemin.js
+++ b/test/test-usemin.js
@@ -4,6 +4,7 @@ var assert = require('assert');
 var grunt = require('grunt');
 var rimraf = require('rimraf');
 var mkdirp = require('mkdirp');
+var helpers = require('./helpers');
 
 grunt.task.init([]);
 grunt.config.init({});
@@ -287,7 +288,11 @@ describe('usemin', function () {
     grunt.file.mkdir('images');
     grunt.file.write('images/test.2132.png', 'foo');
     grunt.file.write('images/test.2134.png', 'foo');
-    grunt.file.write('summary.js', '{"images/test.png": "images/test.2134.png"}');
+
+    var summary = {};
+    summary[helpers.normalize('images/test.png')] = 'images/test.2134.png';
+
+    grunt.file.write('summary.js', JSON.stringify(summary));
     grunt.log.muted = true;
     grunt.config.init();
     grunt.config('usemin', {
@@ -310,10 +315,11 @@ describe('usemin', function () {
     // grunt.file.mkdir('images');
     // grunt.file.write('images/test.2132.png', 'foo');
     // grunt.file.write('images/test.2134.png', 'foo');
+    var summary = {};
+    summary[helpers.normalize('images/test.png')] = 'images/test.2134.png';
+
     grunt.filerev = {
-      summary: {
-        'images/test.png': 'images/test.2134.png'
-      }
+      summary: summary
     };
     grunt.log.muted = true;
     grunt.config.init();


### PR DESCRIPTION
Hi. I have executed tests on Windows and they were failing due to backslashes in path. I have used hepers.normalize to normalize them on Windows. This resulted in saving 'images\\test.png' in summary.js. Unfortunately this was not enough since file content was 'images\test.png' so instead of backslash we had \t. I have added JSON.stringify as well to make sure it will be ok.

Thanks