### PR TITLE
Pass options.type to FileProcessor if present

### DIFF
--- a/tasks/usemin.js
+++ b/tasks/usemin.js
@@ -112,7 +112,6 @@ module.exports = function (grunt) {
 
     debug('Looking at %s target', this.target);
     var patterns = [];
-    var type = this.target;
 
     // Check if we have a user defined pattern
     if (options.patterns && options.patterns[this.target]) {
@@ -123,7 +122,7 @@ module.exports = function (grunt) {
     // var locator = options.revmap ? grunt.file.readJSON(options.revmap) : function (p) { return grunt.file.expand({filter: 'isFile'}, p); };
     var locator = getLocator(grunt, options);
     var revvedfinder = new RevvedFinder(locator);
-    var handler = new FileProcessor(type, patterns, revvedfinder, function (msg) {
+    var handler = new FileProcessor(options.type, patterns, revvedfinder, function (msg) {
       grunt.verbose.writeln(msg);
     }, blockReplacements);
 


### PR DESCRIPTION
This should address some of the issues experienced in yeoman/grunt-usemin#255 when using configuration like the following:

```coffee
usemin:
  "foo-html":
    files:
      src: ["src/www/index.html"]

    options:
      type: "html"
```

This change allows FileProcessor to process the file as `html` instead of `foo-html`, the latter of which won't get built-in pattern support.