### PR TITLE
Adding Custom Search Option

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,23 @@ Default: `nil`
 
 The root directory from which your files will be resolved.
 
+### customSearch
+
+Type: 'regex'  
+Default: Empty
+
+A custom regular expression for creating configurations based on scripts and styles included using non standard methods. 
+
+For example:
+
+The Blade template language in Laravel 5 generated script tags with this syntax. 
+
+```html
+{!! HTML::script('scripts/vendor/bootstrap/bootstrap-button.js') !!}
+```
+
+This option allows you to pass in a regular expression to find scripts included using this method to generate your config. 
+
 ### flow
 
 Type: 'object'  

--- a/lib/configwriter.js
+++ b/lib/configwriter.js
@@ -6,10 +6,10 @@ var _ = require('lodash');
 var deepMerge = function (origCfg, cfg) {
   var outCfg = origCfg;
 
-// If the newly generated part is already in the config file
-// with the same destination update only the source part, instead of add the whole block again.
-// This way the same targets wont be regenerated multiple times if usemin is called
-// multiple times which can happen with grunt-watcher spawn:false mode (#307)
+  // If the newly generated part is already in the config file
+  // with the same destination update only the source part, instead of add the whole block again.
+  // This way the same targets wont be regenerated multiple times if usemin is called
+  // multiple times which can happen with grunt-watcher spawn:false mode (#307)
 
   if (origCfg.files && cfg.files) {
     var done = false;
@@ -149,14 +149,14 @@ ConfigWriter.prototype.forEachStep = function (blockType, cb) {
 // If file is a string it will be considered as the filepath,
 // otherwise it should be an object that conforms to File (in lib/file.js) API
 //
-ConfigWriter.prototype.process = function (file, config) {
+ConfigWriter.prototype.process = function (file, config, customSearch) {
   var self = this;
   var lfile = file;
 
   config = config || {};
 
   if (_.isString(file)) {
-    lfile = new File(file);
+    lfile = new File(file, customSearch);
   }
 
   lfile.blocks.forEach(function (block) {

--- a/lib/file.js
+++ b/lib/file.js
@@ -33,7 +33,7 @@ var fs = require('fs');
 //    <!-- build:css /foo/css/site.css -->
 // then dest will equal foo/css/site.css (note missing trailing /)
 //
-var getBlocks = function (content) {
+var getBlocks = function (content, customSearch) {
   // start build pattern: will match
   //  * <!-- build:[target] output -->
   //  * <!-- build:[target](alternate search path) output -->
@@ -100,6 +100,11 @@ var getBlocks = function (content) {
 
     if (block && last) {
       var asset = l.match(/(href|src)=["']([^'"]+)["']/);
+
+      if (customSearch && !asset) {
+        asset = l.match(customSearch);
+      }
+
       if (asset && asset[2]) {
         last.src.push(asset[2]);
 
@@ -148,7 +153,7 @@ var getBlocks = function (content) {
 };
 
 
-module.exports = function (filepath) {
+module.exports = function (filepath, customSearch) {
   this.dir = path.dirname(filepath);
   this.name = path.basename(filepath);
   // By default referenced content will be looked at relative to the location
@@ -157,5 +162,5 @@ module.exports = function (filepath) {
   this.content = fs.readFileSync(filepath).toString();
 
   // Let's parse !!!
-  this.blocks = getBlocks(this.content);
+  this.blocks = getBlocks(this.content, customSearch);
 };

--- a/tasks/usemin.js
+++ b/tasks/usemin.js
@@ -157,6 +157,7 @@ module.exports = function (grunt) {
     var dest = options.dest || 'dist';
     var staging = options.staging || '.tmp';
     var root = options.root;
+    var customSearch = options.customSearch;
 
     grunt.verbose
       .writeln('Going through ' + grunt.log.wordlist(this.filesSrc) + ' to update the config')
@@ -185,7 +186,7 @@ module.exports = function (grunt) {
     this.filesSrc.forEach(function (filepath) {
       var config;
       try {
-        config = c.process(filepath, grunt.config());
+        config = c.process(filepath, grunt.config(), customSearch);
       } catch (e) {
         grunt.fail.warn(e);
       }

--- a/test/fixtures/block_with_blade_template_includes.html
+++ b/test/fixtures/block_with_blade_template_includes.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<!--[if lt IE 7]>      <html class="no-js lt-ie9 lt-ie8 lt-ie7"> <![endif]-->
+<!--[if IE 7]>         <html class="no-js lt-ie9 lt-ie8"> <![endif]-->
+<!--[if IE 8]>         <html class="no-js lt-ie9"> <![endif]-->
+<!--[if gt IE 8]><!--> <html class="no-js"> <!--<![endif]-->
+    <head>
+        <meta charset="utf-8">
+        <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+        <title></title>
+        <meta name="description" content="">
+        <meta name="viewport" content="width=device-width">
+
+        <!-- Place favicon.ico and apple-touch-icon.png in the root directory -->
+
+
+        <!-- build:css /styles/main.min.css -->
+        {!! HTML::style('styles/main.css') !!}
+        <!-- endbuild -->
+        {!! HTML::script('scripts/vendor/modernizr.min.js') !!}
+    </head>
+    <body>
+    <div class="container" style="margin-top:50px">
+        <div class="hero-unit">
+            <h1>Wotcha!</h1>
+            <p>You now have</p>
+            <ul>
+                <li>HTML5 Boilerplate</li>
+                <li>Bootstrap</li>
+                <li>Bootstrap plugins</li>
+                <li>RequireJS</li>
+                <li>Support for ES6 Modules</li>
+            </ul>
+            <p>installed.</p>
+            <h3>Enjoy coding! - Yeoman</h3>
+        </div>
+    </div>
+
+        <!--[if lt IE 7]>
+            <p class="chromeframe">You are using an outdated browser. <a href="http://browsehappy.com/">Upgrade your browser today</a> or <a href="http://www.google.com/chromeframe/?redirect=true">install Google Chrome Frame</a> to better experience this site.</p>
+        <![endif]-->
+
+        <!-- Add your site or application content here -->
+
+        <script src="//ajax.googleapis.com/ajax/libs/jquery/1.8.0/jquery.min.js"></script>
+        <script>window.jQuery || document.write('<script src="scripts/vendor/jquery.min.js"><\/script>')</script>
+
+
+
+        <!-- Google Analytics: change UA-XXXXX-X to be your site's ID. -->
+        <script>
+            var _gaq=[['_setAccount','UA-XXXXX-X'],['_trackPageview']];
+            (function(d,t){var g=d.createElement(t),s=d.getElementsByTagName(t)[0];
+            g.src=('https:'==location.protocol?'//ssl':'//www')+'.google-analytics.com/ga.js';
+            s.parentNode.insertBefore(g,s)}(document,'script'));
+        </script>
+
+    <!-- build:js /scripts/plugins.js -->
+    {!! HTML::script('scripts/vendor/bootstrap/bootstrap-affix.js') !!}
+    {!! HTML::script('scripts/vendor/bootstrap/bootstrap-alert.js') !!}
+    {!! HTML::script('scripts/vendor/bootstrap/bootstrap-dropdown.js') !!}
+    {!! HTML::script('scripts/vendor/bootstrap/bootstrap-tooltip.js') !!}
+    {!! HTML::script('scripts/vendor/bootstrap/bootstrap-modal.js') !!}
+    {!! HTML::script('scripts/vendor/bootstrap/bootstrap-transition.js') !!}
+
+    {!! HTML::script('scripts/vendor/bootstrap/bootstrap-button.js') !!}
+    {!! HTML::script('scripts/vendor/bootstrap/bootstrap-popover.js') !!}
+    {!! HTML::script('scripts/vendor/bootstrap/bootstrap-typeahead.js') !!}
+    {!! HTML::script('scripts/vendor/bootstrap/bootstrap-carousel.js') !!}
+    {!! HTML::script('scripts/vendor/bootstrap/bootstrap-scrollspy.js') !!}
+    {!! HTML::script('scripts/vendor/bootstrap/bootstrap-collapse.js') !!}
+    {!! HTML::script('scripts/vendor/bootstrap/bootstrap-tab.js') !!}
+    <!-- endbuild -->
+
+    <a href="<?php echo URL::to('admin/create') ?>"><i class='icon-plus icon-white'></i>&nbsp;&nbsp;New</a>
+    <img src="images/test.png">
+    <img src="images/misc/test.png">
+    <img src="//images/test.png">
+    <img src="/images/test.png">
+    <a href="http://foo/bar"></a><a href="ftp://bar"></a><a href="images/test.png"></a><a href="/images/test.png"></a><a href="#local"></a>
+    <a href="foo.html"></a>
+</body>
+</html>
+

--- a/test/fixtures/block_with_jade_script.jade
+++ b/test/fixtures/block_with_jade_script.jade
@@ -1,0 +1,3 @@
+<!-- build:js foo.js -->
+  script(src='bar.js')
+<!-- endbuild -->

--- a/test/test-usemin.js
+++ b/test/test-usemin.js
@@ -429,6 +429,37 @@ describe('useminPrepare', function () {
     assert.deepEqual(uglify.generated.files[0].src, [path.normalize('.tmp/concat/scripts/foo.js')]);
   });
 
+
+  it('should allow for custom search paramaters for js and css, using blade template for testing ', function () {
+    grunt.log.muted = true;
+    grunt.config.init();
+    grunt.config('useminPrepare', {
+      html: 'index.html',
+      options: {
+        customSearch: /{!!\s+HTML::(style|script)\('(\S+)'\)\s+!!}/
+      }
+    });
+    grunt.file.copy(path.join(__dirname, 'fixtures/block_with_blade_template_includes.html'), 'index.html');
+    grunt.task.run('useminPrepare');
+    grunt.task.start();
+
+    var concat = grunt.config('concat');
+
+    assert.ok(concat);
+    assert.ok(concat.generated.files);
+    assert.equal(concat.generated.files.length, 2);
+
+    assert.equal(concat.generated.files[1].dest, path.normalize('.tmp/concat/scripts/plugins.js'));
+    assert.equal(concat.generated.files[1].src.length, 13);
+    assert.equal(concat.generated.files[0].dest, path.normalize('.tmp/concat/styles/main.min.css'));
+    assert.equal(concat.generated.files[0].src.length, 1);
+
+    var uglify = grunt.config('uglify');
+
+    assert.equal(uglify.generated.files[0].dest, path.normalize('dist/scripts/plugins.js'));
+    assert.deepEqual(uglify.generated.files[0].src, [path.normalize('.tmp/concat/scripts/plugins.js')]);
+  });
+
   describe('absolute path', function () {
     // This is an interesting test case: root file is foo, html file is in foo/build and js
     // sources in foo/scripts


### PR DESCRIPTION
This is a dup of #532 with squashed commits. 
Allows a configuration variable of customSearch to be passed so template languages that have helpers for scripts and styles can still utilize usemin. 

```js
    useminPrepare: {
  			production: {
  				src: ['<%= views %>/**/*.blade.*'],
  				options : {
  					root: '<%= htdocs %>',
  					staging: '.tmp',
  					dest: '<%= htdocs %>',
  					customSearch: /{!!\s+HTML::(style|script)\('(\S+)'\)\s+!!}/
  				},
  			}

		},
```