### PR TITLE
Pass self instance of FileProcessor as second argument to filterIn function

### DIFF
--- a/lib/fileprocessor.js
+++ b/lib/fileprocessor.js
@@ -210,7 +210,7 @@ FileProcessor.prototype.replaceWithRevved = function replaceWithRevved(lines, as
         return match;
       }
 
-      var res = match.replace(src, filterOut(file));
+      var res = match.replace(src, filterOut(file, self));
       if (srcFile !== file) {
         self.log(chalk.cyan(src) + ' changed to ' + chalk.cyan(file));
       }

--- a/lib/fileprocessor.js
+++ b/lib/fileprocessor.js
@@ -196,7 +196,7 @@ FileProcessor.prototype.replaceWithRevved = function replaceWithRevved(lines, as
     self.log(rxl[1]);
     content = content.replace(rxl[0], function (match, src) {
       // Consider reference from site root
-      var srcFile = filterIn(src);
+      var srcFile = filterIn(src, self);
 
       debug('Let\'s replace ' + src);
 


### PR DESCRIPTION
In my case I need to know name of currently processed file to update references. I don't think, that this additional parameter will hurt anyone.