### PR TITLE
Preserves 'ng-if' attribute in link element for CSS. Needs to be expn…

### DIFF
--- a/lib/file.js
+++ b/lib/file.js
@@ -109,6 +109,12 @@ var getBlocks = function (content) {
           last.media = media[1];
         }
 
+        var ngif = l.match(/ng-if=\"([^\"]+)(\")+/);
+        // FIXME: ng attribute should be present for all members of the block *and* having the same value
+        if (ngif) {
+            last.ngif = ngif[1];
+        }
+
         // preserve defer attribute
         var defer = / defer/.test(l);
         if (defer && last.defer === false || last.defer && !defer) {

--- a/lib/fileprocessor.js
+++ b/lib/fileprocessor.js
@@ -107,7 +107,8 @@ var _defaultPatterns = {
 var defaultBlockReplacements = {
   css: function (block) {
     var media = block.media ? ' media="' + block.media + '"' : '';
-    return '<link rel="stylesheet" href="' + block.dest + '"' + media + '>';
+    var ngif = block.ngif ? ' ng-if="' + block.ngif + '"' : '';
+    return '<link rel="stylesheet" href="' + block.dest + '"' + media + ngif + '>';
   },
   js: function (block) {
     var defer = block.defer ? 'defer ' : '';


### PR DESCRIPTION
Support to preserve "ng-if" attribute from link element has been added. This functionality can be expanded to "ng-*" attributes and for JS, LESS etc.

Let me know. We can work this out.

Thanks. 