### PR TITLE
Fix image src attributes on minified html.

### DIFF
--- a/lib/fileprocessor.js
+++ b/lib/fileprocessor.js
@@ -15,7 +15,7 @@ var _defaultPatterns = {
       'Update the HTML with the new css filenames'
     ],
     [
-      /<img[^\>]*[^\>\S]+src=['"]([^'"\)#]+)(#.+)?["']/gm,
+      /<img[^\>]*[^\>\S]+src=['"]([^'"#]+)(#[^'"]+)?["']/gm,
       'Update the HTML with the new img filenames'
     ],
     [


### PR DESCRIPTION
It failed if there was no newline character at the end of the `<img>` tag. Replaced only the first occurrence.