### PR TITLE
usemin option to prefix generated paths (eg. CDN)

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,28 +174,28 @@ useminPrepare: {
 
 ### dest
 
-Type: 'string'  
+Type: 'string'
 Default: `nil`
 
 Base directory where the transformed files should be output.
 
 ### staging
 
-Type: 'string'  
+Type: 'string'
 Default: `.tmp`
 
 Base directory where the temporary files should be output (e.g. concatenated files).
 
 ### root
 
-Type: 'string' or 'Array'  
+Type: 'string' or 'Array'
 Default: `nil`
 
 The root directory from which your files will be resolved.
 
 ### flow
 
-Type: 'object'  
+Type: 'object'
 Default: `{ steps: { js: ['concat', 'uglify'], css: ['concat', 'cssmin'] }, post: {} }`
 
 This allow you to configure the workflow, either on a per-target basis, or for all the targets.
@@ -365,7 +365,7 @@ By default `usemin` will look under `dist/html` for revved versions of `styles/m
 
 #### assetsDirs
 
-Type: 'Array'  
+Type: 'Array'
 Default: Single item array set to the value of the directory where the currently looked at file is.
 
 List of directories where we should start to look for *revved version* of the assets referenced in the currently looked at file.
@@ -389,7 +389,7 @@ In others words, given the configuration above, `usemin` will search for the exi
 
 #### patterns
 
-Type: 'Object'  
+Type: 'Object'
 Default: Empty
 
 Allows for user defined pattern to replace reference to files. For example, let's suppose that you want to replace
@@ -424,7 +424,7 @@ So in short:
 
 #### blockReplacements
 
-Type: 'Object'  
+Type: 'Object'
 Default: `{ css: function (block) { ... }, js: function (block) { ... } }`
 
 This lets you define how blocks get their content replaced. Useful to have block types other that `css` and `js`.
@@ -451,7 +451,7 @@ usemin: {
 
 #### revmap
 
-Type: 'String'  
+Type: 'String'
 Default: Empty
 
 Indicate the location of a map file, as produced by `grunt-filerev` for example. This map file is a simple JSON file, holding an object
@@ -463,6 +463,40 @@ which attributes are the original file and associated value is the transformed f
 }
 ```
 This map will be used instead of looking for file on the disk.
+
+#### prefix
+
+Type: 'String'
+Default: Empty
+
+Add a prefix to the generated paths.
+
+For example:
+
+```js
+{
+  "usemin": {
+    "options": {
+      "prefix": "cdn.example.com"
+    }
+  }
+}
+```
+
+The following block
+
+```html
+<!-- build:js scripts/site.js -->
+<script src="foo.js"></script>
+<script src="bar.js"></script>
+<!-- endbuild -->
+```
+
+Will result in:
+
+```html
+<script src="cdn.example.com/scripts/site.js"></script>
+```
 
 ## On directories
 The main difference to be kept in mind, regarding directories and tasks, is that for `useminPrepare`, the directories needs to indicate the input,

--- a/lib/fileprocessor.js
+++ b/lib/fileprocessor.js
@@ -105,18 +105,20 @@ var _defaultPatterns = {
 // Default block replacement functions, for css and js types
 //
 var defaultBlockReplacements = {
-  css: function (block) {
+  css: function (block, prefix) {
+    prefix = prefix || '';
     var media = block.media ? ' media="' + block.media + '"' : '';
-    return '<link rel="stylesheet" href="' + block.dest + '"' + media + '>';
+    return '<link rel="stylesheet" href="' + prefix + block.dest + '"' + media + '>';
   },
-  js: function (block) {
+  js: function (block, prefix) {
+    prefix = prefix || '';
     var defer = block.defer ? 'defer ' : '';
     var async = block.async ? 'async ' : '';
-    return '<script ' + defer + async + 'src="' + block.dest + '"><\/script>';
+    return '<script ' + defer + async + 'src="' + prefix + block.dest + '"><\/script>';
   }
 };
 
-var FileProcessor = module.exports = function (type, patterns, finder, logcb, blockReplacements) {
+var FileProcessor = module.exports = function (type, patterns, finder, logcb, blockReplacements, options) {
   if (!type) {
     throw new Error('No type given');
   }
@@ -131,6 +133,7 @@ var FileProcessor = module.exports = function (type, patterns, finder, logcb, bl
     this.patterns = this.patterns.concat(patterns);
   }
 
+  this.options = options || {};
   this.log = logcb || function () {};
 
   if (!finder) {
@@ -162,13 +165,14 @@ FileProcessor.prototype.replaceBlocks = function replaceBlocks(file) {
 
 FileProcessor.prototype.replaceWith = function replaceWith(block) {
   var result;
+  var prefix = this.options.prefix;
   var conditionalStart = block.conditionalStart ? block.conditionalStart + '\n' + block.indent : '';
   var conditionalEnd = block.conditionalEnd ? '\n' + block.indent + block.conditionalEnd : '';
   if (typeof block.src === 'undefined' || block.src === null || block.src.length === 0) {
     // there are no css or js files in the block, remove it completely
     result = '';
   } else if (_.contains(_.keys(this.blockReplacements), block.type)) {
-    result = block.indent + conditionalStart + this.blockReplacements[block.type](block) + conditionalEnd;
+    result = block.indent + conditionalStart + this.blockReplacements[block.type](block, prefix) + conditionalEnd;
   } else {
     result = '';
   }

--- a/tasks/usemin.js
+++ b/tasks/usemin.js
@@ -125,7 +125,7 @@ module.exports = function (grunt) {
     var revvedfinder = new RevvedFinder(locator);
     var handler = new FileProcessor(type, patterns, revvedfinder, function (msg) {
       grunt.verbose.writeln(msg);
-    }, blockReplacements);
+    }, blockReplacements, options);
 
     this.files.forEach(function (fileObj) {
       var files = grunt.file.expand({

--- a/test/test-fileprocessor.js
+++ b/test/test-fileprocessor.js
@@ -124,6 +124,34 @@ describe('FileProcessor', function () {
       assert.equal(result, '  custom replacement for foo.css');
     });
 
+    it('should prefix paths for default replacement functions', function () {
+      var fp = new FileProcessor('html', [], {}, function () {}, {}, {
+        prefix: 'custom/prefix/'
+      });
+      var block = {
+        dest: 'foo.css',
+        type: 'css',
+        src: ['bar.css'],
+        indent: '  '
+      };
+
+      var result = fp.replaceWith(block);
+      assert.equal(result, '  <link rel="stylesheet" href="custom/prefix/foo.css">');
+
+      fp = new FileProcessor('html', [], {}, function () {}, {}, {
+        prefix: 'custom/prefix/'
+      });
+      block = {
+        dest: 'foo.js',
+        type: 'js',
+        src: ['bar.js'],
+        indent: '  '
+      };
+
+      result = fp.replaceWith(block);
+      assert.equal(result, '  <script src="custom/prefix/foo.js"><\/script>');
+    });
+
     it('should preserve defer attribute (JS)', function () {
       var fp = new FileProcessor('html', [], {});
       var block = {


### PR DESCRIPTION
This is another take on https://github.com/yeoman/grunt-usemin/pull/329 (hopefully this goes through).

Creates a new `usemin` option `prefix` that contains a string to be prefixed on the generated paths.


For example:

```js
{
  "usemin": {
    "options": {
      "prefix": "cdn.example.com"
    }
  }
}
```

The following block

```html
<!-- build:js scripts/site.js -->
<script src="foo.js"></script>
<script src="bar.js"></script>
<!-- endbuild -->
```

Will result in:

```html
<script src="cdn.example.com/scripts/site.js"></script>
```

