### PR TITLE
Add support for Multiple targets.

### DIFF
--- a/tasks/usemin.js
+++ b/tasks/usemin.js
@@ -105,19 +105,35 @@ module.exports = function (grunt) {
 
   grunt.registerMultiTask('usemin', 'Replaces references to non-minified scripts / stylesheets', function () {
     var debug = require('debug')('usemin:usemin');
+    var type = this.target;
+    // If type is not html/css/js and the customized configuration provides 'type' in options. Below is the example.
+    // usemin: {
+    //  test: {
+    //    src : ['dist/index.html'],
+    //    options: {
+    //      type: 'html',
+    //      assertDirs: ['****']
+    //    }
+    //  }
+    // }
+    if ((type !== 'html' && type !== 'css' && type !== 'js') && grunt.config('usemin')[this.target] && grunt.config('usemin')[this.target].options && grunt.config('usemin')[this.target].options.type) {
+      type = grunt.config('usemin')[this.target].options.type;
+    } // else leave as current implementation
+
+    // grunt.config('usemin')[this.target].options.type
+
     var options = this.options({
-      type: this.target
+      type: type
     });
     var blockReplacements = options.blockReplacements || {};
 
     debug('Looking at %s target', this.target);
     var patterns = [];
-    var type = this.target;
 
     // Check if we have a user defined pattern
-    if (options.patterns && options.patterns[this.target]) {
-      debug('Adding user defined patterns for %s', this.target);
-      patterns = options.patterns[this.target];
+    if (options.patterns && options.patterns[type]) {
+      debug('Adding user defined patterns for %s', type);
+      patterns = options.patterns[type];
     }
 
     // var locator = options.revmap ? grunt.file.readJSON(options.revmap) : function (p) { return grunt.file.expand({filter: 'isFile'}, p); };

--- a/test/test-usemin.js
+++ b/test/test-usemin.js
@@ -337,6 +337,35 @@ describe('usemin', function () {
     // Check replace has performed its duty
     assert.equal(changed, '<link rel="stylesheet" href="styles/main.css">');
   });
+  it('should accept coustomized configuration for multiple targets', function () {
+    grunt.file.mkdir('images');
+    grunt.file.write('images/test.2132.png', 'foo');
+    grunt.file.write('images/test.2134.png', 'foo');
+
+    var summary = {};
+    summary[helpers.normalize('images/test.png')] = 'images/test.2134.png';
+
+    grunt.file.write('summary.js', JSON.stringify(summary));
+    grunt.log.muted = true;
+    grunt.config.init();
+    grunt.config('usemin', {
+      customizedConfiguration: {
+        src: ['index.html'],
+        options: {
+          type: 'html',
+          revmap: 'summary.js'
+        }
+      }
+    });
+    grunt.file.copy(path.join(__dirname, 'fixtures/usemin.html'), 'index.html');
+    grunt.task.run('usemin');
+    grunt.task.start();
+
+    var changed = grunt.file.read('index.html');
+    // Check replace has performed its duty
+    assert.ok(changed.match('<img src="images/test.2134.png">'));
+
+  });
 });
 
 describe('useminPrepare', function () {


### PR DESCRIPTION
The code change focused on change "usemin" task to accept multiple targets. Now it is possible to use 'usemin' task like this:

```
usemin: {
    app1: {
        src: ['dist/app1/index.html'],
        options: {
            type: 'html',
            assertDirs: ['dist/app1/images/{,*/}*.png']
        }
    },
    app2: {
        src: ['dist/app2/index.html'],
        options: {
            type: 'html',
            assertDirs: ['dist/app2/images/{,*/}*.png']
        }
    },
}
```
